### PR TITLE
docs(claude): add branch rebase reminder

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -405,3 +405,4 @@ pre-commit install --hook-type commit-msg
 - Binary name is `common-repo` (matches the package name in Cargo.toml).
 - When reviewing changes, always look for flimsy or axiomatic tests that don't really test anything.
 - When reviewing changes, always check for TODOs or other stubbed implementation items.
+- before you push a branch remember to rebase it on main and resolve and conflict


### PR DESCRIPTION
## Summary
- Add reminder in CLAUDE.md to rebase branches on main before pushing

## Context
This documentation update adds a reminder for developers (particularly when using Claude Code) to rebase their feature branches on main and resolve any conflicts before pushing. This helps maintain a clean git history and avoid merge conflicts.

## Changes
- Added rebase reminder to the "Important Notes for Development" section in CLAUDE.md

## Testing
- No functional changes, documentation only

🤖 Generated with [Claude Code](https://claude.com/claude-code)