### PR TITLE
feat(tests): add Phase 1 discovery error handling tests

### DIFF
--- a/context/current-task.json
+++ b/context/current-task.json
@@ -1,10 +1,10 @@
 {
-  "task": "phases-discovery-errors",
+  "task": "phases-processing",
   "plan": "context/improving-test-coverage-plan.json",
-  "instructions": "Add tests for Phase 1 (Discovery & Cloning) error handling. Review existing Phase 1 code paths and write tests for error handling, cycle detection edge cases, config parsing errors, and network fallback logic.",
+  "instructions": "Add tests for Phase 2 (Processing) in phases.rs. Review existing Phase 2 code paths and write tests for cache key generation, operation fingerprinting, and serialization edge cases.",
   "context": {
-    "target_file": "src/phases/discovery.rs",
-    "related_files": ["src/phases/processing.rs", "src/phases/mod.rs"],
+    "target_file": "src/phases/processing.rs",
+    "related_files": ["src/phases/mod.rs", "src/phases/discovery.rs"],
     "note": "The merge-related tasks (phases-merge-yaml, etc.) may be outdated - we just completed comprehensive integration tests for src/merge/ modules."
   },
   "completed_plans": [

--- a/context/improving-test-coverage-plan.json
+++ b/context/improving-test-coverage-plan.json
@@ -1,6 +1,6 @@
 {
   "plan_name": "Improving Test Coverage",
-  "last_updated": "2025-11-30",
+  "last_updated": "2025-12-01",
   "goal": "Target: 90%+ overall line coverage",
   "session_startup": [
     "Run git status to check branch",
@@ -191,10 +191,10 @@
     {
       "id": "phases-discovery-errors",
       "name": "Add tests for Phase 1 (Discovery & Cloning) error handling in phases.rs",
-      "status": "pending",
+      "status": "complete",
       "priority": 2,
       "blocked_by": null,
-      "output_file": "src/phases.rs",
+      "output_file": "src/phases/discovery.rs",
       "steps": [
         "Review existing Phase 1 code paths in phases.rs",
         "Write tests for error handling in discovery",
@@ -206,7 +206,8 @@
         "All Phase 1 error paths have test coverage",
         "Cycle detection edge cases are tested",
         "All tests pass: cargo test phases"
-      ]
+      ],
+      "notes": "Added 21 tests covering: process_config_to_node, detect_cycles, clone_parallel error handling"
     },
     {
       "id": "phases-processing",


### PR DESCRIPTION
- Add 21 tests for discovery.rs covering:
  - process_config_to_node: empty config, repo operations, mixed
    operations, local URL cycle detection
  - detect_cycles: no cycle cases, direct/indirect cycles, local
    root skipping, different refs
  - clone_parallel: empty tree, single/multiple repos, nested repos,
    network error fallback, non-network error propagation
- Update task plan to mark phases-discovery-errors as complete
- Set next task to phases-processing