### PR TITLE
feat(tests): add INI merge operation tests

### DIFF
--- a/context/current-task.json
+++ b/context/current-task.json
@@ -1,9 +1,9 @@
 {
-  "task": "phases-merge-ini",
+  "task": "phases-merge-markdown",
   "plan": "context/improving-test-coverage-plan.json",
-  "instructions": "Add tests for INI merge operations in phases.rs. Review INI merge operator implementation and write tests for section creation, key-value updates, and error paths.",
+  "instructions": "Add tests for Markdown merge operations. Review Markdown merge operator implementation and write tests for header level handling, content insertion modes, and error paths.",
   "context": {
-    "target_file": "src/merge/ini.rs",
+    "target_file": "src/merge/markdown.rs",
     "related_files": ["src/merge/mod.rs"],
     "note": "The merge-related tasks may be partially covered by the comprehensive integration tests in src/merge/ modules."
   },

--- a/context/improving-test-coverage-plan.json
+++ b/context/improving-test-coverage-plan.json
@@ -1,6 +1,6 @@
 {
   "plan_name": "Improving Test Coverage",
-  "last_updated": "2025-12-01T06:45:00Z",
+  "last_updated": "2025-12-01T07:55:00Z",
   "goal": "Target: 90%+ overall line coverage",
   "session_startup": [
     "Run git status to check branch",
@@ -297,10 +297,10 @@
     {
       "id": "phases-merge-ini",
       "name": "Add tests for INI merge operations in phases.rs",
-      "status": "pending",
+      "status": "complete",
       "priority": 2,
       "blocked_by": null,
-      "output_file": "src/phases.rs",
+      "output_file": "src/merge/ini.rs",
       "steps": [
         "Review INI merge operator implementation",
         "Write tests for section creation",
@@ -312,7 +312,8 @@
         "Section creation and key-value updates are tested",
         "Error paths are covered",
         "All tests pass"
-      ]
+      ],
+      "notes": "Added 31 new tests in 4 modules: apply_ini_merge_operation_tests (+5 tests), error_path_tests (8 tests), helper_function_tests (9 tests), edge_case_tests (13 tests). Total INI tests: 46"
     },
     {
       "id": "phases-merge-markdown",


### PR DESCRIPTION
Add 31 new tests for INI merge operations covering:
- Error paths (file not found, invalid UTF-8)
- Merge mode combinations (append/replace with duplicates)
- Helper functions (find_section, ensure_trailing_newline)
- Edge cases (whitespace, special chars, case sensitivity)

Total INI tests: 46