### PR TITLE
chore(context): complete tarpaulin slow coverage investigation

### DIFF
--- a/context/current-task.json
+++ b/context/current-task.json
@@ -1,66 +1,11 @@
 {
-  "task": null,
-  "plan": null,
+  "task": "Implement tarpaulin coverage speed fixes",
+  "plan": "context/tarpaulin-coverage-fixes.json",
   "last_updated": "2025-12-02",
-  "status": "complete",
-  "completed_task": {
-    "name": "Investigate slow tarpaulin coverage due to ignored E2E tests",
-    "completed_at": "2025-12-02",
-    "investigation_findings": {
-      "problem_confirmed": "Tarpaulin instruments all 27 test binaries regardless of #[ignore] status, spending ~55 seconds per binary",
-      "test_structure": {
-        "total_e2e_files": 15,
-        "total_e2e_lines": 5420,
-        "files_without_feature_gating": [
-          "cli_e2e_diff.rs",
-          "cli_e2e_init.rs",
-          "cli_e2e_ls.rs",
-          "cli_e2e_validate.rs"
-        ],
-        "files_with_feature_gating": 11
-      },
-      "tarpaulin_options_evaluated": {
-        "lib_only": {
-          "command": "cargo tarpaulin --lib --ignore-tests",
-          "time": "~2 minutes",
-          "coverage": "89.18%",
-          "limitation": "No E2E coverage"
-        },
-        "exclude_files": {
-          "command": "cargo tarpaulin --exclude-files 'tests/*'",
-          "limitation": "Still instruments binaries, only excludes from results"
-        },
-        "test_flag": {
-          "command": "cargo tarpaulin --test <name>",
-          "limitation": "Must specify each test manually"
-        },
-        "config_file": {
-          "file": "tarpaulin.toml or .tarpaulin.toml",
-          "option": "run-types = [\"Lib\"]",
-          "benefit": "Codifies --lib behavior in config"
-        }
-      },
-      "root_cause_analysis": {
-        "why_feature_gated": "E2E tests require network access (clone repos) and binary compilation. Feature gating allows cargo test to skip them by default while cargo test --features integration-tests runs them explicitly.",
-        "why_not_cfg_test": "cfg(test) would still compile the tests. Feature gating with #[ignore] allows the binary to exist but tests to be skipped at runtime.",
-        "inconsistency_found": "4 of 15 E2E files lack the feature gating pattern"
-      },
-      "recommendations": {
-        "immediate": {
-          "action": "Create .tarpaulin.toml with run-types = [\"Lib\"]",
-          "benefit": "Fast coverage (~2 min) without command-line flags",
-          "tradeoff": "No E2E coverage in tarpaulin"
-        },
-        "short_term": {
-          "action": "Add #[cfg_attr(not(feature = \"integration-tests\"), ignore)] to 4 ungated E2E files",
-          "benefit": "Consistent test behavior across all E2E files"
-        },
-        "long_term": {
-          "action": "Consolidate 15 cli_e2e_*.rs files into one tests/cli_e2e.rs with modules",
-          "benefit": "Reduces binaries from 15 to 1, cutting E2E instrumentation time by ~14x",
-          "effort": "Refactor ~5400 lines of test code"
-        }
-      }
-    }
+  "status": "pending",
+  "context": {
+    "investigation_completed": true,
+    "problem": "Tarpaulin takes ~25 minutes because it instruments all 27 test binaries",
+    "solution": "Create tarpaulin config for lib-only coverage and fix inconsistent E2E feature gating"
   }
 }

--- a/context/tarpaulin-coverage-fixes.json
+++ b/context/tarpaulin-coverage-fixes.json
@@ -1,0 +1,134 @@
+{
+  "plan_name": "Tarpaulin Coverage Speed Fixes",
+  "last_updated": "2025-12-02",
+  "session_startup": [
+    "Run git status to check branch",
+    "Run ./script/test to verify baseline",
+    "Read this file to find current task",
+    "Find first task where status=pending and blocked_by=null"
+  ],
+  "tasks": [
+    {
+      "id": "create-tarpaulin-config",
+      "name": "Create .tarpaulin.toml configuration file",
+      "status": "pending",
+      "priority": 1,
+      "blocked_by": null,
+      "output_file": ".tarpaulin.toml",
+      "steps": [
+        "Create .tarpaulin.toml in project root",
+        "Set run-types = [\"Lib\"] to only run library tests",
+        "Add ignore-tests = true to exclude test function lines from coverage",
+        "Add timeout = \"120s\" for reasonable test timeout",
+        "Verify with: cargo tarpaulin --print-rust-flags"
+      ],
+      "acceptance_criteria": [
+        "File .tarpaulin.toml exists in project root",
+        "Running cargo tarpaulin uses config automatically",
+        "Coverage runs in ~2 minutes instead of ~25 minutes"
+      ]
+    },
+    {
+      "id": "fix-e2e-diff-gating",
+      "name": "Add feature gating to cli_e2e_diff.rs",
+      "status": "pending",
+      "priority": 2,
+      "blocked_by": null,
+      "output_file": "tests/cli_e2e_diff.rs",
+      "steps": [
+        "Read tests/cli_e2e_diff.rs to understand current structure",
+        "Add #[cfg_attr(not(feature = \"integration-tests\"), ignore)] to each #[test] function",
+        "Run cargo test to verify tests are ignored without feature",
+        "Run cargo test --features integration-tests to verify tests run with feature"
+      ],
+      "acceptance_criteria": [
+        "All tests in file have the cfg_attr ignore attribute",
+        "cargo test shows tests as ignored",
+        "cargo test --features integration-tests runs the tests"
+      ]
+    },
+    {
+      "id": "fix-e2e-init-gating",
+      "name": "Add feature gating to cli_e2e_init.rs",
+      "status": "pending",
+      "priority": 2,
+      "blocked_by": null,
+      "output_file": "tests/cli_e2e_init.rs",
+      "steps": [
+        "Read tests/cli_e2e_init.rs to understand current structure",
+        "Add #[cfg_attr(not(feature = \"integration-tests\"), ignore)] to each #[test] function",
+        "Run cargo test to verify tests are ignored without feature",
+        "Run cargo test --features integration-tests to verify tests run with feature"
+      ],
+      "acceptance_criteria": [
+        "All tests in file have the cfg_attr ignore attribute",
+        "cargo test shows tests as ignored",
+        "cargo test --features integration-tests runs the tests"
+      ]
+    },
+    {
+      "id": "fix-e2e-ls-gating",
+      "name": "Add feature gating to cli_e2e_ls.rs",
+      "status": "pending",
+      "priority": 2,
+      "blocked_by": null,
+      "output_file": "tests/cli_e2e_ls.rs",
+      "steps": [
+        "Read tests/cli_e2e_ls.rs to understand current structure",
+        "Add #[cfg_attr(not(feature = \"integration-tests\"), ignore)] to each #[test] function",
+        "Run cargo test to verify tests are ignored without feature",
+        "Run cargo test --features integration-tests to verify tests run with feature"
+      ],
+      "acceptance_criteria": [
+        "All tests in file have the cfg_attr ignore attribute",
+        "cargo test shows tests as ignored",
+        "cargo test --features integration-tests runs the tests"
+      ]
+    },
+    {
+      "id": "fix-e2e-validate-gating",
+      "name": "Add feature gating to cli_e2e_validate.rs",
+      "status": "pending",
+      "priority": 2,
+      "blocked_by": null,
+      "output_file": "tests/cli_e2e_validate.rs",
+      "steps": [
+        "Read tests/cli_e2e_validate.rs to understand current structure",
+        "Add #[cfg_attr(not(feature = \"integration-tests\"), ignore)] to each #[test] function",
+        "Run cargo test to verify tests are ignored without feature",
+        "Run cargo test --features integration-tests to verify tests run with feature"
+      ],
+      "acceptance_criteria": [
+        "All tests in file have the cfg_attr ignore attribute",
+        "cargo test shows tests as ignored",
+        "cargo test --features integration-tests runs the tests"
+      ]
+    },
+    {
+      "id": "verify-all-fixes",
+      "name": "Verify all fixes and run final tests",
+      "status": "pending",
+      "priority": 3,
+      "blocked_by": "create-tarpaulin-config",
+      "output_file": null,
+      "steps": [
+        "Run ./script/test to ensure all unit tests pass",
+        "Run cargo test --features integration-tests to verify E2E tests work",
+        "Run cargo tarpaulin to verify fast coverage (~2 min)",
+        "Verify coverage percentage is still ~89%"
+      ],
+      "acceptance_criteria": [
+        "All unit tests pass",
+        "All E2E tests pass with --features integration-tests",
+        "cargo tarpaulin completes in ~2 minutes",
+        "Coverage is approximately 89%"
+      ]
+    }
+  ],
+  "notes": [
+    "Tasks with priority 2 can run in parallel (feature gating fixes are independent)",
+    "The tarpaulin config task should be done first as it provides immediate benefit",
+    "Feature gating fixes improve consistency but don't directly speed up tarpaulin",
+    "E2E test consolidation is deferred as a future optimization"
+  ]
+}


### PR DESCRIPTION
Investigated why tarpaulin takes ~25 minutes with E2E tests:
- Tarpaulin instruments all 27 binaries regardless of #[ignore]
- 4 of 15 E2E files lack feature gating consistency
- Documented root cause and recommendations

Recommendations:
- Immediate: Create .tarpaulin.toml with run-types = ["Lib"]
- Short-term: Add feature gating to 4 ungated E2E files
- Long-term: Consolidate 15 E2E files into one binary