### PR TITLE
test: add insta snapshot testing for CLI output

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -168,6 +168,33 @@ Breaking changes should be indicated with either:
 - Aim for 80%+ code coverage
 - Use descriptive test names: `test_function_does_something_when_condition()`
 
+#### Snapshot Testing
+
+This project uses [insta](https://insta.rs) for snapshot testing of CLI output. Snapshot tests capture CLI help text and error messages to detect unintended changes.
+
+**Running snapshot tests:**
+```bash
+cargo test --test cli_snapshot_tests
+```
+
+**Updating snapshots after intentional changes:**
+```bash
+# Review and accept pending snapshots interactively
+cargo insta review
+
+# Or accept all pending snapshots at once
+cargo insta accept
+```
+
+**Adding new snapshot tests:**
+1. Add a new test function in `tests/cli_snapshot_tests.rs`
+2. Use `insta::assert_snapshot!("name", output)` to capture output
+3. Run the test to generate a `.snap.new` file
+4. Review and accept the snapshot
+5. Commit both the test and the `.snap` file
+
+Snapshot files are stored in `tests/snapshots/` and should be committed to version control.
+
 ### Performance
 
 - Avoid unnecessary allocations

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -286,6 +286,7 @@ dependencies = [
  "env_logger",
  "glob",
  "indicatif",
+ "insta",
  "log",
  "predicates",
  "ptree",
@@ -905,6 +906,19 @@ dependencies = [
  "portable-atomic",
  "unicode-width",
  "web-time",
+]
+
+[[package]]
+name = "insta"
+version = "1.45.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "983e3b24350c84ab8a65151f537d67afbbf7153bb9f1110e03e9fa9b07f67a5c"
+dependencies = [
+ "console",
+ "once_cell",
+ "serde 1.0.228",
+ "similar",
+ "tempfile",
 ]
 
 [[package]]
@@ -1667,6 +1681,12 @@ dependencies = [
  "quote",
  "syn 2.0.110",
 ]
+
+[[package]]
+name = "similar"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
 
 [[package]]
 name = "slab"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ ptree = "0.4"
 tempfile = "3.0"
 datatest-stable = "0.1"
 serial_test = "3.0"
+insta = { version = "1.41", features = ["yaml"] }
 # CLI E2E testing dependencies
 assert_cmd = "2.0"
 predicates = "3.1"

--- a/context/testing-review.json
+++ b/context/testing-review.json
@@ -3,10 +3,10 @@
   "description": "Improve testing practices to meet OSS best practices",
   "last_updated": "2025-12-31",
   "audit_summary": {
-    "current_score": "7/10",
-    "pass": ["2.1 Unit tests inline", "2.2 Integration tests in tests/", "2.3 Uses cargo-nextest", "2.4 Doctests run separately", "2.5 Coverage measured (tarpaulin)", "2.6 Coverage target enforced (80%)", "2.8 CI profile configured"],
+    "current_score": "8/10",
+    "pass": ["2.1 Unit tests inline", "2.2 Integration tests in tests/", "2.3 Uses cargo-nextest", "2.4 Doctests run separately", "2.5 Coverage measured (tarpaulin)", "2.6 Coverage target enforced (80%)", "2.8 CI profile configured", "2.9 Snapshot testing (insta)"],
     "partial": ["2.7 Test helpers (exist but could be improved)"],
-    "fail": ["2.9 Snapshot testing (insta)", "2.10 Property-based testing (proptest)"]
+    "fail": ["2.10 Property-based testing (proptest)"]
   },
   "tasks": [
     {
@@ -47,7 +47,7 @@
     {
       "id": "add-snapshot-testing",
       "name": "Add insta for snapshot testing",
-      "status": "pending",
+      "status": "complete",
       "priority": 2,
       "blocked_by": null,
       "steps": [
@@ -61,7 +61,8 @@
         "insta is added as dev-dependency",
         "At least 3 snapshot tests exist",
         "Snapshot files committed to repo"
-      ]
+      ],
+      "completion_notes": "Added insta v1.41 with yaml feature. Created tests/cli_snapshot_tests.rs with 7 snapshot tests covering main help, subcommand helps (apply, check, ls, init), and error messages (missing config, invalid subcommand). Documented workflow in CONTRIBUTING.md."
     },
     {
       "id": "add-property-testing",

--- a/tests/cli_snapshot_tests.rs
+++ b/tests/cli_snapshot_tests.rs
@@ -1,0 +1,129 @@
+//! Snapshot tests for CLI output using insta.
+//!
+//! These tests capture CLI help text and error messages as snapshots,
+//! making it easy to review changes to user-facing output.
+//!
+//! To update snapshots after intentional changes:
+//! ```bash
+//! cargo insta test --accept
+//! ```
+
+use assert_cmd::cargo::cargo_bin_cmd;
+
+/// Normalize version and path-dependent parts of CLI output for stable snapshots
+fn normalize_output(output: &str) -> String {
+    // Replace version numbers to make snapshots stable across releases
+    let re = regex::Regex::new(r"common-repo \d+\.\d+\.\d+").unwrap();
+    let versioned = re.replace_all(output, "common-repo [VERSION]");
+    // Strip trailing whitespace from each line to match pre-commit formatting
+    versioned
+        .lines()
+        .map(|line| line.trim_end())
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+#[test]
+fn test_main_help_snapshot() {
+    let mut cmd = cargo_bin_cmd!("common-repo");
+    let output = cmd
+        .arg("--help")
+        .output()
+        .expect("Failed to execute command");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let normalized = normalize_output(&stdout);
+
+    insta::assert_snapshot!("main_help", normalized);
+}
+
+#[test]
+fn test_apply_help_snapshot() {
+    let mut cmd = cargo_bin_cmd!("common-repo");
+    let output = cmd
+        .args(["apply", "--help"])
+        .output()
+        .expect("Failed to execute command");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let normalized = normalize_output(&stdout);
+
+    insta::assert_snapshot!("apply_help", normalized);
+}
+
+#[test]
+fn test_check_help_snapshot() {
+    let mut cmd = cargo_bin_cmd!("common-repo");
+    let output = cmd
+        .args(["check", "--help"])
+        .output()
+        .expect("Failed to execute command");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let normalized = normalize_output(&stdout);
+
+    insta::assert_snapshot!("check_help", normalized);
+}
+
+#[test]
+fn test_ls_help_snapshot() {
+    let mut cmd = cargo_bin_cmd!("common-repo");
+    let output = cmd
+        .args(["ls", "--help"])
+        .output()
+        .expect("Failed to execute command");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let normalized = normalize_output(&stdout);
+
+    insta::assert_snapshot!("ls_help", normalized);
+}
+
+#[test]
+fn test_init_help_snapshot() {
+    let mut cmd = cargo_bin_cmd!("common-repo");
+    let output = cmd
+        .args(["init", "--help"])
+        .output()
+        .expect("Failed to execute command");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let normalized = normalize_output(&stdout);
+
+    insta::assert_snapshot!("init_help", normalized);
+}
+
+#[test]
+fn test_missing_config_error_snapshot() {
+    let temp = tempfile::TempDir::new().unwrap();
+
+    let mut cmd = cargo_bin_cmd!("common-repo");
+    let output = cmd
+        .current_dir(temp.path())
+        .arg("ls")
+        .output()
+        .expect("Failed to execute command");
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    // Extract just the error message line, ignoring stack backtrace which varies by environment
+    let error_line = stderr
+        .lines()
+        .find(|line| line.starts_with("Error:"))
+        .unwrap_or("No error message found");
+
+    insta::assert_snapshot!("missing_config_error", error_line);
+}
+
+#[test]
+fn test_invalid_subcommand_error_snapshot() {
+    let mut cmd = cargo_bin_cmd!("common-repo");
+    let output = cmd
+        .arg("nonexistent-command")
+        .output()
+        .expect("Failed to execute command");
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let normalized = normalize_output(&stderr);
+
+    insta::assert_snapshot!("invalid_subcommand_error", normalized);
+}

--- a/tests/snapshots/cli_snapshot_tests__apply_help.snap
+++ b/tests/snapshots/cli_snapshot_tests__apply_help.snap
@@ -1,0 +1,56 @@
+---
+source: tests/cli_snapshot_tests.rs
+assertion_line: 42
+expression: normalized
+---
+Apply the .common-repo.yaml configuration to the current repository
+
+Usage: common-repo apply [OPTIONS]
+
+Options:
+  -c, --config <PATH>
+          Path to the configuration file.
+
+          If not provided, it defaults to `.common-repo.yaml` in the current directory. Can also be set with the `COMMON_REPO_CONFIG` environment variable.
+
+          [env: COMMON_REPO_CONFIG=]
+
+  -o, --output <PATH>
+          The directory where the final files will be written.
+
+          If not provided, it defaults to the current working directory.
+
+      --cache-root <PATH>
+          The root directory for the repository cache.
+
+          If not provided, it defaults to `~/.common-repo/cache`. Can also be set with the `COMMON_REPO_CACHE` environment variable.
+
+          [env: COMMON_REPO_CACHE=]
+
+  -n, --dry-run
+          If set, the command will show what would be done without making any actual changes to the filesystem
+
+  -f, --force
+          If set, the command will overwrite existing files without prompting. (Currently, there is no prompting, so this is reserved for future use)
+
+  -v, --verbose
+          If set, the command will show detailed progress information during execution
+
+      --no-cache
+          If set, the command will bypass the repository cache and fetch fresh clones of all repositories
+
+  -q, --quiet
+          If set, the command will suppress all output except for errors
+
+      --color <WHEN>
+          Colorize output (always, never, auto)
+
+          [default: auto]
+
+      --log-level <LEVEL>
+          Set log level (error, warn, info, debug, trace)
+
+          [default: info]
+
+  -h, --help
+          Print help (see a summary with '-h')

--- a/tests/snapshots/cli_snapshot_tests__check_help.snap
+++ b/tests/snapshots/cli_snapshot_tests__check_help.snap
@@ -1,0 +1,37 @@
+---
+source: tests/cli_snapshot_tests.rs
+assertion_line: 56
+expression: normalized
+---
+Check configuration validity and check for repository updates
+
+Usage: common-repo check [OPTIONS]
+
+Options:
+  -c, --config <FILE>
+          Path to the .common-repo.yaml configuration file to check
+
+          [default: .common-repo.yaml]
+
+      --cache-root <DIR>
+          The root directory for the repository cache.
+
+          If not provided, it defaults to the system's cache directory (e.g., `~/.cache/common-repo` on Linux). Can also be set with the `COMMON_REPO_CACHE` environment variable.
+
+          [env: COMMON_REPO_CACHE=]
+
+      --updates
+          If set, the command will check for newer versions of the inherited repositories
+
+      --color <WHEN>
+          Colorize output (always, never, auto)
+
+          [default: auto]
+
+      --log-level <LEVEL>
+          Set log level (error, warn, info, debug, trace)
+
+          [default: info]
+
+  -h, --help
+          Print help (see a summary with '-h')

--- a/tests/snapshots/cli_snapshot_tests__init_help.snap
+++ b/tests/snapshots/cli_snapshot_tests__init_help.snap
@@ -1,0 +1,18 @@
+---
+source: tests/cli_snapshot_tests.rs
+assertion_line: 84
+expression: normalized
+---
+Initialize a new .common-repo.yaml configuration file
+
+Usage: common-repo init [OPTIONS]
+
+Options:
+  -i, --interactive          Interactive setup wizard for configuration creation
+  -t, --template <TEMPLATE>  Start from a predefined template (e.g., rust-cli, python-django)
+      --minimal              Create minimal configuration with examples (default)
+      --empty                Create empty configuration file
+  -f, --force                Overwrite existing configuration file
+      --color <WHEN>         Colorize output (always, never, auto) [default: auto]
+      --log-level <LEVEL>    Set log level (error, warn, info, debug, trace) [default: info]
+  -h, --help                 Print help

--- a/tests/snapshots/cli_snapshot_tests__invalid_subcommand_error.snap
+++ b/tests/snapshots/cli_snapshot_tests__invalid_subcommand_error.snap
@@ -1,0 +1,10 @@
+---
+source: tests/cli_snapshot_tests.rs
+assertion_line: 116
+expression: normalized
+---
+error: unrecognized subcommand 'nonexistent-command'
+
+Usage: common-repo [OPTIONS] <COMMAND>
+
+For more information, try '--help'.

--- a/tests/snapshots/cli_snapshot_tests__ls_help.snap
+++ b/tests/snapshots/cli_snapshot_tests__ls_help.snap
@@ -1,0 +1,61 @@
+---
+source: tests/cli_snapshot_tests.rs
+assertion_line: 70
+expression: normalized
+---
+List files that would be created/modified by the configuration
+
+Usage: common-repo ls [OPTIONS]
+
+Options:
+  -c, --config <FILE>
+          Path to the .common-repo.yaml configuration file
+
+          [default: .common-repo.yaml]
+
+      --cache-root <DIR>
+          The root directory for the repository cache.
+
+          If not provided, it defaults to the system's cache directory (e.g., `~/.cache/common-repo` on Linux). Can also be set with the `COMMON_REPO_CACHE` environment variable.
+
+          [env: COMMON_REPO_CACHE=]
+
+      --working-dir <DIR>
+          The working directory for local file operations.
+
+          If not provided, it defaults to the current working directory.
+
+  -p, --pattern <PATTERN>
+          Filter files by glob pattern (e.g., "*.rs", "src/**/*.ts")
+
+  -l, --long
+          Use long listing format showing size and permissions
+
+  -s, --sort <SORT>
+          Sort order for file listing
+
+          Possible values:
+          - name: Sort alphabetically by file name
+          - size: Sort by file size
+          - path: Sort by full path
+
+          [default: name]
+
+      --count
+          Show only the total count of files
+
+  -r, --reverse
+          Reverse the sort order
+
+      --color <WHEN>
+          Colorize output (always, never, auto)
+
+          [default: auto]
+
+      --log-level <LEVEL>
+          Set log level (error, warn, info, debug, trace)
+
+          [default: info]
+
+  -h, --help
+          Print help (see a summary with '-h')

--- a/tests/snapshots/cli_snapshot_tests__main_help.snap
+++ b/tests/snapshots/cli_snapshot_tests__main_help.snap
@@ -1,0 +1,38 @@
+---
+source: tests/cli_snapshot_tests.rs
+assertion_line: 28
+expression: normalized
+---
+Common Repository - Manage repository configuration inheritance
+
+Usage: common-repo [OPTIONS] <COMMAND>
+
+Commands:
+  apply     Apply the .common-repo.yaml configuration to the current repository
+  check     Check configuration validity and check for repository updates
+  diff      Show differences between current files and configuration result
+  init      Initialize a new .common-repo.yaml configuration file
+  update    Update repository refs to newer versions
+  info      Show information about a repository or the current configuration
+  ls        List files that would be created/modified by the configuration
+  validate  Validate a .common-repo.yaml configuration file
+  cache     Manage repository cache
+  tree      Display the repository inheritance tree
+  help      Print this message or the help of the given subcommand(s)
+
+Options:
+      --color <WHEN>
+          Colorize output (always, never, auto)
+
+          [default: auto]
+
+      --log-level <LEVEL>
+          Set log level (error, warn, info, debug, trace)
+
+          [default: info]
+
+  -h, --help
+          Print help (see a summary with '-h')
+
+  -V, --version
+          Print version

--- a/tests/snapshots/cli_snapshot_tests__missing_config_error.snap
+++ b/tests/snapshots/cli_snapshot_tests__missing_config_error.snap
@@ -1,0 +1,6 @@
+---
+source: tests/cli_snapshot_tests.rs
+assertion_line: 114
+expression: error_line
+---
+Error: Configuration file not found: .common-repo.yaml


### PR DESCRIPTION
Add snapshot testing using insta crate for capturing and verifying CLI
help text and error messages. This enables detecting unintended changes
to user-facing output.

- Add insta v1.41 as dev-dependency with yaml feature
- Create 7 snapshot tests for CLI help and error output
- Document snapshot testing workflow in CONTRIBUTING.md
- Update testing-review.json task status