### PR TITLE
refactor(init): remove deprecated flags and templates

### DIFF
--- a/context/current-task.json
+++ b/context/current-task.json
@@ -1,5 +1,5 @@
 {
-  "task": "remove-deprecated-flags",
+  "task": "update-init-documentation",
   "plan": "context/init-redesign.json",
   "last_updated": "2025-12-31",
   "status": "pending",
@@ -12,10 +12,10 @@
       "context/completed/cicd-review.json"
     ],
     "current_subplan": "context/init-redesign.json",
-    "notes": "Next unblocked task: remove-deprecated-flags (priority 4). After this, update-init-documentation (priority 5) is blocked by remove-deprecated-flags.",
+    "notes": "Next unblocked task: update-init-documentation (priority 5). This is the final task in the init-redesign plan.",
     "recently_completed": {
-      "task": "update-install-script-prek",
-      "summary": "Added optional prek installation to install.sh. INSTALL_PREK=1 env var installs prek automatically. Interactive installs (TTY detected) prompt user. Downloads prek binary from GitHub releases to same directory as common-repo. Shows success message with prek version after installation."
+      "task": "remove-deprecated-flags",
+      "summary": "Removed deprecated --minimal, --empty, and --template flags from InitArgs. Removed generate_empty_config(), generate_minimal_config(), generate_template_config(), and all template generation functions. Updated execute() to default to interactive wizard. Updated unit tests and E2E tests. Updated snapshot test for init --help output."
     }
   }
 }

--- a/context/init-redesign.json
+++ b/context/init-redesign.json
@@ -99,7 +99,7 @@
     {
       "id": "remove-deprecated-flags",
       "name": "Remove deprecated init flags (--minimal, --empty, --template)",
-      "status": "pending",
+      "status": "complete",
       "priority": 4,
       "blocked_by": "implement-interactive-wizard",
       "steps": [

--- a/src/commands/init.rs
+++ b/src/commands/init.rs
@@ -1,14 +1,13 @@
 //! # Init Command Implementation
 //!
 //! This module implements the `init` subcommand, which creates new `.common-repo.yaml`
-//! configuration files with different initialization modes.
+//! configuration files through an interactive setup wizard.
 //!
 //! ## Functionality
 //!
-//! - **Minimal Config**: Creates a basic configuration with example operations and comments
-//! - **Empty Config**: Creates an empty configuration file with minimal structure
-//! - **Template Config**: Uses predefined templates for common tech stacks
-//! - **Interactive Config**: Guides users through configuration creation via CLI wizard
+//! - **Interactive Wizard**: Default mode that guides users through configuration creation
+//! - **URI Argument**: Initialize from an existing repository URL
+//! - **Pre-commit Setup**: Optional integration with pre-commit hooks (prek or pre-commit)
 //! - **Force Mode**: Overwrites existing configuration files when specified
 
 use anyhow::Result;
@@ -28,21 +27,9 @@ pub struct InitArgs {
     #[arg(value_name = "URI")]
     pub uri: Option<String>,
 
-    /// Interactive setup wizard for configuration creation
+    /// Interactive setup wizard for configuration creation (default when no URI provided)
     #[arg(short, long)]
     pub interactive: bool,
-
-    /// Start from a predefined template (e.g., rust-cli, python-django)
-    #[arg(short, long, value_name = "TEMPLATE")]
-    pub template: Option<String>,
-
-    /// Create minimal configuration with examples (default)
-    #[arg(long)]
-    pub minimal: bool,
-
-    /// Create empty configuration file
-    #[arg(long)]
-    pub empty: bool,
 
     /// Overwrite existing configuration file
     #[arg(short, long)]
@@ -52,7 +39,8 @@ pub struct InitArgs {
 /// Execute the `init` command.
 ///
 /// This function handles the logic for the `init` subcommand, creating
-/// `.common-repo.yaml` files based on the specified initialization mode.
+/// `.common-repo.yaml` files. The default behavior is to run the interactive
+/// wizard, unless a URI argument is provided.
 pub fn execute(args: InitArgs) -> Result<()> {
     let config_path = Path::new(".common-repo.yaml");
 
@@ -65,17 +53,11 @@ pub fn execute(args: InitArgs) -> Result<()> {
 
     println!("🎯 Initializing common-repo configuration...");
 
-    let config_content = if args.empty {
-        generate_empty_config()
-    } else if let Some(template) = &args.template {
-        generate_template_config(template)?
-    } else if let Some(uri) = &args.uri {
+    let config_content = if let Some(uri) = &args.uri {
         generate_config_from_uri(uri)?
-    } else if args.interactive {
-        generate_interactive_config()?
     } else {
-        // Default to minimal
-        generate_minimal_config()
+        // Default to interactive wizard
+        generate_interactive_config()?
     };
 
     // Write the configuration file
@@ -84,72 +66,6 @@ pub fn execute(args: InitArgs) -> Result<()> {
     println!("💡 Run `common-repo apply` to fetch and apply configurations");
 
     Ok(())
-}
-
-/// Generate an empty configuration file.
-fn generate_empty_config() -> String {
-    r#"# common-repo configuration
-# This file defines which repository configurations to inherit
-
-# Add your repository configurations here
-# See https://github.com/common-repo/common-repo for documentation
-
-"#
-    .to_string()
-}
-
-/// Generate a minimal configuration with examples and comments.
-fn generate_minimal_config() -> String {
-    r#"# common-repo configuration
-# This file defines which repository configurations to inherit
-
-# Example: Inherit from a common Rust CLI setup
-- repo:
-    url: https://github.com/common-repo/rust-cli
-    ref: v1.2.0
-
-# Include specific files from inherited repos
-- include:
-    patterns:
-      - "**/*"
-
-# Exclude files you don't want
-- exclude:
-    patterns:
-      - "**/*.md"
-
-# Example: Template processing
-- template:
-    patterns:
-      - "**/*.template"
-
-- template-vars:
-    project_name: ${PROJECT_NAME:-my-project}
-    author: ${AUTHOR:-Your Name}
-
-# Example: Merge configuration fragments
-- yaml:
-    source: config.yml
-    dest: .github/workflows/ci.yml
-    path: jobs.test.steps
-    append: true
-
-"#
-    .to_string()
-}
-
-/// Generate configuration from a predefined template.
-fn generate_template_config(template_name: &str) -> Result<String> {
-    match template_name {
-        "rust-cli" => Ok(generate_rust_cli_template()),
-        "python-django" => Ok(generate_python_django_template()),
-        "node-typescript" => Ok(generate_node_typescript_template()),
-        "go-service" => Ok(generate_go_service_template()),
-        _ => Err(anyhow::anyhow!(
-            "Unknown template '{}'. Available templates: rust-cli, python-django, node-typescript, go-service",
-            template_name
-        )),
-    }
 }
 
 /// Generate configuration from a repository URI.
@@ -476,164 +392,6 @@ fn build_config_from_repos(repos: &[RepoEntry]) -> String {
     config
 }
 
-/// Generate Rust CLI template configuration.
-fn generate_rust_cli_template() -> String {
-    r#"# Rust CLI Application Configuration
-# Inherits common Rust CLI project setup
-
-- repo:
-    url: https://github.com/common-repo/rust-cli
-    ref: v1.2.0
-
-- repo:
-    url: https://github.com/common-repo/ci-rust
-    ref: v2.1.0
-
-- repo:
-    url: https://github.com/common-repo/pre-commit-hooks
-    ref: v1.5.0
-
-- include:
-    patterns:
-      - "**/*"
-
-- exclude:
-    patterns:
-      - "**/*.md"
-      - "docs/**"
-
-- template:
-    patterns:
-      - "**/*.template"
-
-- template-vars:
-    project_name: ${PROJECT_NAME:-my-rust-cli}
-    author: ${AUTHOR:-Your Name}
-    rust_version: ${RUST_VERSION:-1.70}
-
-"#
-    .to_string()
-}
-
-/// Generate Python Django template configuration.
-fn generate_python_django_template() -> String {
-    r#"# Python Django Application Configuration
-# Inherits common Python Django project setup
-
-- repo:
-    url: https://github.com/common-repo/python-django
-    ref: v2.0.0
-
-- repo:
-    url: https://github.com/common-repo/ci-python
-    ref: v1.8.0
-
-- repo:
-    url: https://github.com/common-repo/pre-commit-hooks
-    ref: v1.5.0
-
-- include:
-    patterns:
-      - "**/*"
-
-- exclude:
-    patterns:
-      - "**/*.md"
-      - "docs/**"
-
-- template:
-    patterns:
-      - "**/*.template"
-
-- template-vars:
-    project_name: ${PROJECT_NAME:-my-django-app}
-    author: ${AUTHOR:-Your Name}
-    python_version: ${PYTHON_VERSION:-3.9}
-    django_version: ${DJANGO_VERSION:-4.2}
-
-"#
-    .to_string()
-}
-
-/// Generate Node.js TypeScript template configuration.
-fn generate_node_typescript_template() -> String {
-    r#"# Node.js TypeScript Application Configuration
-# Inherits common Node.js TypeScript project setup
-
-- repo:
-    url: https://github.com/common-repo/node-typescript
-    ref: v1.9.0
-
-- repo:
-    url: https://github.com/common-repo/ci-node
-    ref: v1.7.0
-
-- repo:
-    url: https://github.com/common-repo/pre-commit-hooks
-    ref: v1.5.0
-
-- include:
-    patterns:
-      - "**/*"
-
-- exclude:
-    patterns:
-      - "**/*.md"
-      - "docs/**"
-
-- template:
-    patterns:
-      - "**/*.template"
-
-- template-vars:
-    project_name: ${PROJECT_NAME:-my-node-app}
-    author: ${AUTHOR:-Your Name}
-    node_version: ${NODE_VERSION:-18}
-    typescript_version: ${TYPESCRIPT_VERSION:-5.0}
-
-"#
-    .to_string()
-}
-
-/// Generate Go service template configuration.
-fn generate_go_service_template() -> String {
-    r#"# Go Service Configuration
-# Inherits common Go service project setup
-
-- repo:
-    url: https://github.com/common-repo/go-service
-    ref: v1.6.0
-
-- repo:
-    url: https://github.com/common-repo/ci-go
-    ref: v1.4.0
-
-- repo:
-    url: https://github.com/common-repo/pre-commit-hooks
-    ref: v1.5.0
-
-- include:
-    patterns:
-      - "**/*"
-
-- exclude:
-    patterns:
-      - "**/*.md"
-      - "docs/**"
-
-- template:
-    patterns:
-      - "**/*.template"
-
-- template-vars:
-    project_name: ${PROJECT_NAME:-my-go-service}
-    author: ${AUTHOR:-Your Name}
-    go_version: ${GO_VERSION:-1.20}
-
-"#
-    .to_string()
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -641,170 +399,10 @@ mod tests {
     use std::env;
     use tempfile::TempDir;
 
-    #[test]
-    fn test_generate_empty_config() {
-        let config = generate_empty_config();
-        assert!(config.contains("# common-repo configuration"));
-        assert!(config.contains("# Add your repository configurations here"));
-    }
-
-    #[test]
-    fn test_generate_minimal_config() {
-        let config = generate_minimal_config();
-        assert!(config.contains("# common-repo configuration"));
-        assert!(config.contains("repo:"));
-        assert!(config.contains("include:"));
-        assert!(config.contains("exclude:"));
-        assert!(config.contains("template:"));
-        assert!(config.contains("template-vars:"));
-    }
-
-    #[test]
-    fn test_generate_template_config_rust_cli() {
-        let config = generate_template_config("rust-cli").unwrap();
-        assert!(config.contains("rust-cli"));
-        assert!(config.contains("ci-rust"));
-        assert!(config.contains("pre-commit-hooks"));
-    }
-
-    #[test]
-    fn test_generate_template_config_python_django() {
-        let config = generate_template_config("python-django").unwrap();
-        assert!(config.contains("python-django"));
-        assert!(config.contains("ci-python"));
-    }
-
-    #[test]
-    fn test_generate_template_config_unknown() {
-        let result = generate_template_config("unknown-template");
-        assert!(result.is_err());
-        assert!(result.unwrap_err().to_string().contains("Unknown template"));
-    }
-
-    #[test]
-    #[serial]
-    fn test_execute_force_flag() {
-        let original_dir = env::current_dir().unwrap();
-        let temp_dir = TempDir::new().unwrap();
-        env::set_current_dir(&temp_dir).unwrap();
-
-        // Create existing config file
-        fs::write(".common-repo.yaml", "existing content").unwrap();
-
-        // Try to init without force - should fail
-        let args = InitArgs {
-            uri: None,
-            interactive: false,
-            template: None,
-            minimal: true,
-            empty: false,
-            force: false,
-        };
-
-        let result = execute(args);
-        assert!(result.is_err());
-        assert!(result.unwrap_err().to_string().contains("already exists"));
-
-        // Try with force - should succeed
-        let args = InitArgs {
-            uri: None,
-            interactive: false,
-            template: None,
-            minimal: true,
-            empty: false,
-            force: true,
-        };
-
-        let result = execute(args);
-        assert!(result.is_ok());
-
-        let content = fs::read_to_string(".common-repo.yaml").unwrap();
-        assert!(content.contains("# common-repo configuration"));
-
-        env::set_current_dir(original_dir).unwrap();
-    }
-
-    #[test]
-    #[serial]
-    fn test_execute_empty_config() {
-        let original_dir = env::current_dir().unwrap();
-        let temp_dir = TempDir::new().unwrap();
-        env::set_current_dir(&temp_dir).unwrap();
-
-        let args = InitArgs {
-            uri: None,
-            interactive: false,
-            template: None,
-            minimal: false,
-            empty: true,
-            force: false,
-        };
-
-        let result = execute(args);
-        assert!(result.is_ok());
-
-        let content = fs::read_to_string(".common-repo.yaml").unwrap();
-        assert!(content.contains("# common-repo configuration"));
-        assert!(content.contains("# Add your repository configurations here"));
-
-        env::set_current_dir(original_dir).unwrap();
-    }
-
-    #[test]
-    #[serial]
-    fn test_execute_minimal_config() {
-        let original_dir = env::current_dir().unwrap();
-        let temp_dir = TempDir::new().unwrap();
-        env::set_current_dir(&temp_dir).unwrap();
-
-        let args = InitArgs {
-            uri: None,
-            interactive: false,
-            template: None,
-            minimal: true,
-            empty: false,
-            force: false,
-        };
-
-        let result = execute(args);
-        assert!(result.is_ok());
-
-        let content = fs::read_to_string(".common-repo.yaml").unwrap();
-        assert!(content.contains("repo:"));
-        assert!(content.contains("include:"));
-
-        env::set_current_dir(original_dir).unwrap();
-    }
-
-    #[test]
-    #[serial]
-    fn test_execute_template_config() {
-        let original_dir = env::current_dir().unwrap();
-        let temp_dir = TempDir::new().unwrap();
-        env::set_current_dir(&temp_dir).unwrap();
-
-        let args = InitArgs {
-            uri: None,
-            interactive: false,
-            template: Some("rust-cli".to_string()),
-            minimal: false,
-            empty: false,
-            force: false,
-        };
-
-        let result = execute(args);
-        assert!(result.is_ok());
-
-        let content = fs::read_to_string(".common-repo.yaml").unwrap();
-        assert!(content.contains("rust-cli"));
-        assert!(content.contains("ci-rust"));
-
-        env::set_current_dir(original_dir).unwrap();
-    }
-
-    // Note: test_execute_interactive_config is skipped because dialoguer
-    // requires a TTY for interactive prompts. Interactive mode is tested
-    // manually or via E2E tests with TTY simulation.
+    // Note: execute() tests are skipped because dialoguer requires a TTY
+    // for interactive prompts (which is now the default). Interactive mode
+    // is tested via E2E tests with TTY simulation in tests/cli_e2e_init_interactive.rs.
+    // The force flag behavior is tested via E2E tests in tests/cli_e2e_init.rs.
 
     #[test]
     fn test_normalize_repo_url_full_url() {

--- a/tests/cli_e2e_init.rs
+++ b/tests/cli_e2e_init.rs
@@ -2,224 +2,14 @@
 //!
 //! These tests invoke the actual CLI binary and validate the behavior of the
 //! `init` subcommand from a user's perspective.
+//!
+//! Note: The default `init` behavior is now an interactive wizard that requires
+//! TTY simulation. Most interactive tests are in `cli_e2e_init_interactive.rs`.
+//! This file tests the non-interactive modes (URI argument, force flag, etc).
 
 use assert_cmd::cargo::cargo_bin_cmd;
 use assert_fs::prelude::*;
 use predicates::prelude::*;
-
-#[test]
-#[cfg_attr(not(feature = "integration-tests"), ignore)]
-fn test_init_minimal_config() {
-    let temp = assert_fs::TempDir::new().unwrap();
-
-    let mut cmd = cargo_bin_cmd!("common-repo");
-
-    cmd.current_dir(temp.path())
-        .arg("init")
-        .arg("--minimal")
-        .assert()
-        .success()
-        .stdout(predicate::str::contains(
-            "🎯 Initializing common-repo configuration",
-        ))
-        .stdout(predicate::str::contains("✅ Created .common-repo.yaml"))
-        .stdout(predicate::str::contains("💡 Run `common-repo apply`"));
-
-    // Check that the config file was created with expected content
-    let config_file = temp.child(".common-repo.yaml");
-    config_file.assert(predicate::path::exists());
-    config_file.assert(predicate::str::contains("# common-repo configuration"));
-    config_file.assert(predicate::str::contains("repo:"));
-    config_file.assert(predicate::str::contains("include:"));
-    config_file.assert(predicate::str::contains("exclude:"));
-    config_file.assert(predicate::str::contains("template:"));
-    config_file.assert(predicate::str::contains("template-vars:"));
-}
-
-#[test]
-#[cfg_attr(not(feature = "integration-tests"), ignore)]
-fn test_init_empty_config() {
-    let temp = assert_fs::TempDir::new().unwrap();
-
-    let mut cmd = cargo_bin_cmd!("common-repo");
-
-    cmd.current_dir(temp.path())
-        .arg("init")
-        .arg("--empty")
-        .assert()
-        .success()
-        .stdout(predicate::str::contains(
-            "🎯 Initializing common-repo configuration",
-        ))
-        .stdout(predicate::str::contains("✅ Created .common-repo.yaml"));
-
-    // Check that the config file was created with minimal content
-    let config_file = temp.child(".common-repo.yaml");
-    config_file.assert(predicate::path::exists());
-    config_file.assert(predicate::str::contains("# common-repo configuration"));
-    config_file.assert(predicate::str::contains(
-        "# Add your repository configurations here",
-    ));
-    // Should not contain repo operations
-    config_file.assert(
-        predicate::str::contains("# Add your repository configurations here")
-            .not()
-            .or(predicate::str::contains("repo:").not()),
-    );
-}
-
-#[test]
-#[cfg_attr(not(feature = "integration-tests"), ignore)]
-fn test_init_template_rust_cli() {
-    let temp = assert_fs::TempDir::new().unwrap();
-
-    let mut cmd = cargo_bin_cmd!("common-repo");
-
-    cmd.current_dir(temp.path())
-        .arg("init")
-        .arg("--template")
-        .arg("rust-cli")
-        .assert()
-        .success()
-        .stdout(predicate::str::contains(
-            "🎯 Initializing common-repo configuration",
-        ))
-        .stdout(predicate::str::contains("✅ Created .common-repo.yaml"));
-
-    // Check that the config file was created with rust-cli template
-    let config_file = temp.child(".common-repo.yaml");
-    config_file.assert(predicate::path::exists());
-    config_file.assert(predicate::str::contains(
-        "# Rust CLI Application Configuration",
-    ));
-    config_file.assert(predicate::str::contains("common-repo/rust-cli"));
-    config_file.assert(predicate::str::contains("common-repo/ci-rust"));
-    config_file.assert(predicate::str::contains("common-repo/pre-commit-hooks"));
-    config_file.assert(predicate::str::contains("rust_version:"));
-}
-
-#[test]
-#[cfg_attr(not(feature = "integration-tests"), ignore)]
-fn test_init_template_python_django() {
-    let temp = assert_fs::TempDir::new().unwrap();
-
-    let mut cmd = cargo_bin_cmd!("common-repo");
-
-    cmd.current_dir(temp.path())
-        .arg("init")
-        .arg("--template")
-        .arg("python-django")
-        .assert()
-        .success();
-
-    // Check that the config file was created with python-django template
-    let config_file = temp.child(".common-repo.yaml");
-    config_file.assert(predicate::path::exists());
-    config_file.assert(predicate::str::contains(
-        "# Python Django Application Configuration",
-    ));
-    config_file.assert(predicate::str::contains("common-repo/python-django"));
-    config_file.assert(predicate::str::contains("common-repo/ci-python"));
-    config_file.assert(predicate::str::contains("django_version:"));
-}
-
-#[test]
-#[cfg_attr(not(feature = "integration-tests"), ignore)]
-fn test_init_template_unknown() {
-    let temp = assert_fs::TempDir::new().unwrap();
-
-    let mut cmd = cargo_bin_cmd!("common-repo");
-
-    cmd.current_dir(temp.path())
-        .arg("init")
-        .arg("--template")
-        .arg("unknown-template")
-        .assert()
-        .failure()
-        .stderr(predicate::str::contains(
-            "Unknown template 'unknown-template'",
-        ));
-}
-
-#[test]
-#[cfg_attr(not(feature = "integration-tests"), ignore)]
-fn test_init_force_overwrite() {
-    let temp = assert_fs::TempDir::new().unwrap();
-    let config_file = temp.child(".common-repo.yaml");
-
-    // Create existing config file
-    config_file.write_str("existing content").unwrap();
-
-    // Try to init without force - should fail
-    let mut cmd = cargo_bin_cmd!("common-repo");
-    cmd.current_dir(temp.path())
-        .arg("init")
-        .arg("--minimal")
-        .assert()
-        .failure()
-        .stderr(predicate::str::contains(
-            "already exists. Use --force to overwrite",
-        ));
-
-    // Now try with force - should succeed
-    let mut cmd = cargo_bin_cmd!("common-repo");
-    cmd.current_dir(temp.path())
-        .arg("init")
-        .arg("--minimal")
-        .arg("--force")
-        .assert()
-        .success()
-        .stdout(predicate::str::contains("✅ Created .common-repo.yaml"));
-
-    // Verify the content was overwritten
-    config_file.assert(predicate::str::contains("# common-repo configuration"));
-    config_file.assert(predicate::str::contains("existing content").not());
-}
-
-// Note: Interactive mode requires TTY simulation (e.g., rexpect) because dialoguer
-// reads from terminal. This test is disabled until rexpect-based E2E tests are added.
-// See: context/init-redesign.json task "add-init-e2e-tests" for testing plan.
-// See: https://github.com/console-rs/dialoguer/issues/95
-#[test]
-#[ignore = "interactive mode requires TTY - use rexpect for E2E testing"]
-fn test_init_interactive_mode() {
-    let temp = assert_fs::TempDir::new().unwrap();
-
-    let mut cmd = cargo_bin_cmd!("common-repo");
-
-    cmd.current_dir(temp.path())
-        .arg("init")
-        .arg("--interactive")
-        .assert()
-        .success()
-        .stdout(predicate::str::contains("Welcome to common-repo!"))
-        .stdout(predicate::str::contains(
-            "Enter repository URLs to inherit from",
-        ))
-        .stdout(predicate::str::contains("✅ Created .common-repo.yaml"));
-
-    // Check that the config file was created
-    let config_file = temp.child(".common-repo.yaml");
-    config_file.assert(predicate::path::exists());
-    config_file.assert(predicate::str::contains("# common-repo configuration"));
-}
-
-#[test]
-#[cfg_attr(not(feature = "integration-tests"), ignore)]
-fn test_init_default_is_minimal() {
-    let temp = assert_fs::TempDir::new().unwrap();
-
-    let mut cmd = cargo_bin_cmd!("common-repo");
-
-    cmd.current_dir(temp.path()).arg("init").assert().success();
-
-    // Check that the default creates minimal config
-    let config_file = temp.child(".common-repo.yaml");
-    config_file.assert(predicate::path::exists());
-    config_file.assert(predicate::str::contains("repo:"));
-    config_file.assert(predicate::str::contains("include:"));
-    config_file.assert(predicate::str::contains("exclude:"));
-}
 
 #[test]
 #[cfg_attr(not(feature = "integration-tests"), ignore)]
@@ -266,6 +56,45 @@ fn test_init_with_uri_github_shorthand() {
     // Check that the config file was created with expanded URL
     let config_file = temp.child(".common-repo.yaml");
     config_file.assert(predicate::path::exists());
+    config_file.assert(predicate::str::contains(
+        "url: https://github.com/rust-lang/rust-clippy",
+    ));
+}
+
+#[test]
+#[cfg_attr(not(feature = "integration-tests"), ignore)]
+fn test_init_with_uri_force_overwrite() {
+    let temp = assert_fs::TempDir::new().unwrap();
+    let config_file = temp.child(".common-repo.yaml");
+
+    // Create existing config file
+    config_file.write_str("existing content").unwrap();
+
+    // Try to init without force - should fail
+    let mut cmd = cargo_bin_cmd!("common-repo");
+    cmd.current_dir(temp.path())
+        .arg("init")
+        .arg("rust-lang/rust-clippy")
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "already exists. Use --force to overwrite",
+        ));
+
+    // Now try with force - should succeed
+    let mut cmd = cargo_bin_cmd!("common-repo");
+    cmd.current_dir(temp.path())
+        .arg("init")
+        .arg("rust-lang/rust-clippy")
+        .arg("--force")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Fetching tags from"))
+        .stdout(predicate::str::contains("✅ Created .common-repo.yaml"));
+
+    // Verify the content was overwritten
+    config_file.assert(predicate::str::contains("# common-repo configuration"));
+    config_file.assert(predicate::str::contains("existing content").not());
     config_file.assert(predicate::str::contains(
         "url: https://github.com/rust-lang/rust-clippy",
     ));

--- a/tests/snapshots/cli_snapshot_tests__init_help.snap
+++ b/tests/snapshots/cli_snapshot_tests__init_help.snap
@@ -1,6 +1,6 @@
 ---
 source: tests/cli_snapshot_tests.rs
-assertion_line: 84
+assertion_line: 93
 expression: normalized
 ---
 Initialize a new .common-repo.yaml configuration file
@@ -11,11 +11,8 @@ Arguments:
   [URI]  Repository URL to initialize from (e.g., https://github.com/org/repo or org/repo)
 
 Options:
-  -i, --interactive          Interactive setup wizard for configuration creation
-  -t, --template <TEMPLATE>  Start from a predefined template (e.g., rust-cli, python-django)
-      --minimal              Create minimal configuration with examples (default)
-      --empty                Create empty configuration file
-  -f, --force                Overwrite existing configuration file
-      --color <WHEN>         Colorize output (always, never, auto) [default: auto]
-      --log-level <LEVEL>    Set log level (error, warn, info, debug, trace) [default: info]
-  -h, --help                 Print help
+  -i, --interactive        Interactive setup wizard for configuration creation (default when no URI provided)
+  -f, --force              Overwrite existing configuration file
+      --color <WHEN>       Colorize output (always, never, auto) [default: auto]
+      --log-level <LEVEL>  Set log level (error, warn, info, debug, trace) [default: info]
+  -h, --help               Print help


### PR DESCRIPTION
Remove --minimal, --empty, and --template flags from the init command.
The default behavior is now the interactive wizard. Users can still
initialize from a URI directly with the positional argument.

- Remove generate_empty_config, generate_minimal_config, and template functions
- Update execute() to default to interactive mode
- Update unit tests and E2E tests
- Update CLI help snapshot