### PR TITLE
feat(add): implement add command for quick repo addition

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,9 @@ common-repo init
 # Or initialize from an existing repo
 common-repo init https://github.com/your-org/shared-configs
 common-repo init your-org/shared-configs  # GitHub shorthand
+
+# Add more repos to an existing config
+common-repo add your-org/another-repo
 ```
 
 ## Usage
@@ -110,6 +113,7 @@ common-repo update            # Update refs
 
 ```
 init       Create a new .common-repo.yaml
+add        Add a repository to existing config
 apply      Apply configuration (runs 6-phase pipeline)
 diff       Preview changes
 ls         List files that would be created

--- a/context/add-command.json
+++ b/context/add-command.json
@@ -2,13 +2,13 @@
   "plan_name": "Add Command Implementation",
   "description": "Implement common-repo add command for quickly adding repos to config",
   "created": "2025-12-29",
-  "last_updated": "2025-12-29",
+  "last_updated": "2025-12-31",
   "source": "context/session-notes.md",
   "tasks": [
     {
       "id": "create-add-command-module",
       "name": "Create src/commands/add.rs module",
-      "status": "pending",
+      "status": "complete",
       "priority": 1,
       "blocked_by": null,
       "steps": [
@@ -27,7 +27,7 @@
     {
       "id": "implement-config-detection",
       "name": "Implement config file detection and creation logic",
-      "status": "pending",
+      "status": "complete",
       "priority": 2,
       "blocked_by": "create-add-command-module",
       "steps": [
@@ -46,7 +46,7 @@
     {
       "id": "implement-semver-detection",
       "name": "Implement semver tag auto-detection for added repos",
-      "status": "pending",
+      "status": "complete",
       "priority": 2,
       "blocked_by": "create-add-command-module",
       "steps": [
@@ -65,7 +65,7 @@
     {
       "id": "implement-yaml-append",
       "name": "Implement YAML config appending",
-      "status": "pending",
+      "status": "complete",
       "priority": 3,
       "blocked_by": "implement-config-detection",
       "steps": [
@@ -84,7 +84,7 @@
     {
       "id": "add-add-command-tests",
       "name": "Add unit and E2E tests for add command",
-      "status": "pending",
+      "status": "complete",
       "priority": 4,
       "blocked_by": "implement-yaml-append",
       "steps": [
@@ -103,7 +103,7 @@
     {
       "id": "document-add-command",
       "name": "Document add command",
-      "status": "pending",
+      "status": "complete",
       "priority": 5,
       "blocked_by": "implement-yaml-append",
       "steps": [

--- a/context/current-task.json
+++ b/context/current-task.json
@@ -2,7 +2,7 @@
   "task": null,
   "plan": "context/add-command.json",
   "last_updated": "2025-12-31",
-  "status": "pending",
+  "status": "complete",
   "master_plan": "context/plan-of-plans.json",
   "context": {
     "completed_plans": [
@@ -13,11 +13,11 @@
       "context/completed/init-redesign.json"
     ],
     "current_subplan": "context/add-command.json",
-    "notes": "Init redesign complete. Next plan: add-command for quick repo addition feature.",
+    "notes": "Add command implementation complete. All tasks finished: command module created, config detection, semver detection, YAML appending, tests, and documentation.",
     "recently_completed": {
-      "task": "update-init-documentation",
-      "plan": "init-redesign",
-      "summary": "Updated README.md with Quick Start section, updated docs/src/cli.md with new init command options (URI arg, removed deprecated flags), updated docs/src/getting-started.md with interactive wizard description."
+      "task": "document-add-command",
+      "plan": "add-command",
+      "summary": "Implemented common-repo add command for adding repos to config. Includes auto semver detection, interactive prompts, --quiet mode, and comprehensive tests."
     }
   }
 }

--- a/docs/src/cli.md
+++ b/docs/src/cli.md
@@ -15,6 +15,46 @@ These options are available for all commands:
 
 ## Commands
 
+### `add` - Add Repository
+
+Add a repository to an existing `.common-repo.yaml` configuration file. Automatically detects the latest semver tag.
+
+```bash
+common-repo add [OPTIONS] <URI>
+```
+
+#### Arguments
+
+| Argument | Description |
+|----------|-------------|
+| `<URI>` | Repository URL to add (e.g., `https://github.com/org/repo` or `org/repo` GitHub shorthand) |
+
+#### Options
+
+| Option | Description |
+|--------|-------------|
+| `-q, --quiet` | Non-interactive mode: create minimal config without prompting if none exists |
+
+#### Examples
+
+```bash
+# Add a repo to existing config
+common-repo add your-org/shared-configs
+
+# Add using full URL
+common-repo add https://github.com/your-org/shared-configs
+
+# Create new config with --quiet (non-interactive)
+common-repo add --quiet your-org/shared-configs
+```
+
+#### Behavior
+
+- If `.common-repo.yaml` exists: appends the new repository before the `include` section
+- If no config exists: prompts for confirmation to create a minimal config (use `--quiet` to skip prompt)
+- Automatically fetches and uses the latest semver tag, or falls back to `main` if no tags found
+- Warns when adding repositories with only 0.x.x versions (unstable API)
+
 ### `apply` - Apply Configuration
 
 Apply the `.common-repo.yaml` configuration to your repository. This runs the full 6-phase pipeline: discover repos, clone, process, merge, and write files.
@@ -399,10 +439,12 @@ my-project
 ### First-Time Setup
 
 ```bash
-# Initialize config
+# Initialize config interactively
 common-repo init
 
-# Edit .common-repo.yaml to add your repos
+# Or add repos one at a time
+common-repo add your-org/shared-configs
+common-repo add your-org/ci-templates
 
 # Preview what would be created
 common-repo ls

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -43,6 +43,9 @@ pub struct Cli {
 
 #[derive(Subcommand, Debug)]
 enum Commands {
+    /// Add a repository to the configuration file
+    Add(commands::add::AddArgs),
+
     /// Apply the .common-repo.yaml configuration to the current repository
     Apply(commands::apply::ApplyArgs),
 
@@ -81,6 +84,7 @@ impl Cli {
         self.init_logger()?;
 
         match self.command {
+            Commands::Add(args) => commands::add::execute(args),
             Commands::Apply(args) => commands::apply::execute(args),
             Commands::Check(args) => commands::check::execute(args),
             Commands::Diff(args) => {

--- a/src/commands/add.rs
+++ b/src/commands/add.rs
@@ -1,0 +1,367 @@
+//! # Add Command Implementation
+//!
+//! This module implements the `add` subcommand, which adds a repository to an existing
+//! or new `.common-repo.yaml` configuration file.
+//!
+//! ## Functionality
+//!
+//! - **URI Argument**: Add a repository by URL (supports GitHub shorthand like `org/repo`)
+//! - **Semver Detection**: Automatically detects and uses the latest semver tag
+//! - **Config Detection**: Creates config if missing (or invokes init wizard unless --quiet)
+//! - **Quiet Mode**: Non-interactive mode for automation
+
+use anyhow::Result;
+use clap::Args;
+use dialoguer::{theme::ColorfulTheme, Confirm};
+use std::fs;
+use std::path::Path;
+
+use common_repo::git;
+use common_repo::version;
+
+/// Add a repository to the configuration file
+#[derive(Args, Debug)]
+pub struct AddArgs {
+    /// Repository URL to add (e.g., https://github.com/org/repo or org/repo)
+    #[arg(value_name = "URI")]
+    pub uri: String,
+
+    /// Non-interactive mode: create minimal config without prompting if none exists
+    #[arg(short, long)]
+    pub quiet: bool,
+}
+
+/// Execute the `add` command.
+///
+/// This function handles the logic for the `add` subcommand, adding a repository
+/// to the `.common-repo.yaml` configuration file. If no configuration exists,
+/// it either invokes the init wizard (default) or creates a minimal config (--quiet).
+pub fn execute(args: AddArgs) -> Result<()> {
+    let config_path = Path::new(".common-repo.yaml");
+
+    // Normalize URL (expand GitHub shorthand)
+    let url = normalize_repo_url(&args.uri);
+
+    // Fetch version info
+    let (version, warnings) = fetch_version_info(&url);
+
+    // Print warnings
+    for warning in &warnings {
+        eprintln!("  ⚠️  {}", warning);
+    }
+
+    // Check if config exists
+    if config_path.exists() {
+        // Append to existing config
+        append_repo_to_config(config_path, &url, &version)?;
+        println!("✅ Added {} @ {} to .common-repo.yaml", url, version);
+    } else if args.quiet {
+        // Create minimal config with just this repo
+        create_minimal_config(config_path, &url, &version)?;
+        println!("✅ Created .common-repo.yaml with {} @ {}", url, version);
+    } else {
+        // No config exists - ask user for confirmation to create one
+        println!("No .common-repo.yaml configuration file found.");
+        println!();
+
+        let theme = ColorfulTheme::default();
+        let create_config = Confirm::with_theme(&theme)
+            .with_prompt(format!(
+                "Create a new configuration with {} @ {}?",
+                url, version
+            ))
+            .default(true)
+            .interact()?;
+
+        if create_config {
+            create_minimal_config(config_path, &url, &version)?;
+            println!("✅ Created .common-repo.yaml with {} @ {}", url, version);
+            println!("💡 Run `common-repo apply` to fetch and apply configurations");
+        } else {
+            println!("Aborted. Run 'common-repo init' to create a configuration interactively.");
+            return Ok(());
+        }
+    }
+
+    Ok(())
+}
+
+/// Normalize a repository URL, expanding GitHub shorthand.
+fn normalize_repo_url(input: &str) -> String {
+    // If it already looks like a URL, use as-is
+    if input.starts_with("https://") || input.starts_with("git@") || input.starts_with("http://") {
+        return input.to_string();
+    }
+
+    // Expand GitHub shorthand: org/repo -> https://github.com/org/repo
+    if input.contains('/') && !input.contains(':') {
+        return format!("https://github.com/{}", input);
+    }
+
+    input.to_string()
+}
+
+/// Fetch version information from a repository.
+///
+/// Returns the best version to use (latest semver tag or fallback) and any warnings.
+fn fetch_version_info(url: &str) -> (String, Vec<String>) {
+    print!("Fetching tags from {}... ", url);
+
+    match git::list_tags(url) {
+        Ok(tags) => {
+            let semver_tags = version::filter_semver_tags(&tags);
+            if let Some((latest_tag, parsed_version)) = find_latest_version(&semver_tags) {
+                println!("found {}", latest_tag);
+
+                let mut warnings = Vec::new();
+                if parsed_version.major == 0 {
+                    warnings.push(format!(
+                        "Warning: {} is a 0.x.x version, which may indicate unstable API",
+                        latest_tag
+                    ));
+                }
+                (latest_tag, warnings)
+            } else if !tags.is_empty() {
+                println!("no semver tags found");
+                (
+                    "main".to_string(),
+                    vec![
+                        "Warning: No semantic version tags found. Using 'main' branch.".to_string(),
+                        "Consider pinning to a specific commit hash for reproducibility."
+                            .to_string(),
+                    ],
+                )
+            } else {
+                println!("no tags found");
+                (
+                    "main".to_string(),
+                    vec![
+                        "Warning: No tags found. Using 'main' branch.".to_string(),
+                        "Consider pinning to a specific commit hash for reproducibility."
+                            .to_string(),
+                    ],
+                )
+            }
+        }
+        Err(e) => {
+            println!("failed");
+            (
+                "main".to_string(),
+                vec![
+                    format!("Warning: Error fetching tags: {}. Using 'main' branch.", e),
+                    "Consider pinning to a specific commit hash for reproducibility.".to_string(),
+                ],
+            )
+        }
+    }
+}
+
+/// Find the latest semantic version from a list of tags.
+fn find_latest_version(tags: &[String]) -> Option<(String, semver::Version)> {
+    let mut latest: Option<(String, semver::Version)> = None;
+
+    for tag in tags {
+        if let Some(version) = git::parse_semver_tag(tag) {
+            if let Some((_, ref latest_ver)) = latest {
+                if version > *latest_ver {
+                    latest = Some((tag.clone(), version));
+                }
+            } else {
+                latest = Some((tag.clone(), version));
+            }
+        }
+    }
+
+    latest
+}
+
+/// Create a minimal configuration file with a single repository.
+fn create_minimal_config(config_path: &Path, url: &str, version: &str) -> Result<()> {
+    let config = format!(
+        r#"# common-repo configuration
+# Generated by common-repo add
+
+- repo:
+    url: {}
+    ref: {}
+
+- include:
+    patterns:
+      - "**/*"
+"#,
+        url, version
+    );
+
+    fs::write(config_path, config)?;
+    Ok(())
+}
+
+/// Append a repository entry to an existing configuration file.
+fn append_repo_to_config(config_path: &Path, url: &str, version: &str) -> Result<()> {
+    let mut content = fs::read_to_string(config_path)?;
+
+    // Find where to insert the new repo entry (before include section or at end)
+    let new_entry = format!(
+        r#"
+- repo:
+    url: {}
+    ref: {}
+"#,
+        url, version
+    );
+
+    // Try to insert before the include section if it exists
+    if let Some(include_pos) = content.find("- include:") {
+        content.insert_str(include_pos, &new_entry);
+    } else {
+        // Append at end
+        content.push_str(&new_entry);
+    }
+
+    fs::write(config_path, content)?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    #[test]
+    fn test_normalize_repo_url_full_url() {
+        assert_eq!(
+            normalize_repo_url("https://github.com/org/repo"),
+            "https://github.com/org/repo"
+        );
+        assert_eq!(
+            normalize_repo_url("git@github.com:org/repo.git"),
+            "git@github.com:org/repo.git"
+        );
+    }
+
+    #[test]
+    fn test_normalize_repo_url_shorthand() {
+        assert_eq!(
+            normalize_repo_url("org/repo"),
+            "https://github.com/org/repo"
+        );
+        assert_eq!(
+            normalize_repo_url("common-repo/rust-cli"),
+            "https://github.com/common-repo/rust-cli"
+        );
+    }
+
+    #[test]
+    fn test_normalize_repo_url_http() {
+        assert_eq!(
+            normalize_repo_url("http://example.com/repo"),
+            "http://example.com/repo"
+        );
+    }
+
+    #[test]
+    fn test_find_latest_version() {
+        let tags = vec![
+            "v1.0.0".to_string(),
+            "v2.0.0".to_string(),
+            "v1.5.0".to_string(),
+        ];
+        let result = find_latest_version(&tags);
+        assert!(result.is_some());
+        let (tag, _) = result.unwrap();
+        assert_eq!(tag, "v2.0.0");
+    }
+
+    #[test]
+    fn test_find_latest_version_empty() {
+        let tags: Vec<String> = vec![];
+        let result = find_latest_version(&tags);
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn test_find_latest_version_no_semver() {
+        let tags = vec!["main".to_string(), "develop".to_string()];
+        let result = find_latest_version(&tags);
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn test_find_latest_version_zero_major() {
+        let tags = vec![
+            "v0.1.0".to_string(),
+            "v0.5.0".to_string(),
+            "v0.2.3".to_string(),
+        ];
+        let result = find_latest_version(&tags);
+        assert!(result.is_some());
+        let (tag, version) = result.unwrap();
+        assert_eq!(tag, "v0.5.0");
+        assert_eq!(version.major, 0);
+        assert_eq!(version.minor, 5);
+    }
+
+    #[test]
+    fn test_create_minimal_config() {
+        let temp_dir = TempDir::new().unwrap();
+        let config_path = temp_dir.path().join(".common-repo.yaml");
+
+        create_minimal_config(&config_path, "https://github.com/org/repo", "v1.0.0").unwrap();
+
+        let content = fs::read_to_string(&config_path).unwrap();
+        assert!(content.contains("url: https://github.com/org/repo"));
+        assert!(content.contains("ref: v1.0.0"));
+        assert!(content.contains("- include:"));
+    }
+
+    #[test]
+    fn test_append_repo_to_config_with_include() {
+        let temp_dir = TempDir::new().unwrap();
+        let config_path = temp_dir.path().join(".common-repo.yaml");
+
+        // Create initial config with include section
+        let initial_config = r#"# common-repo configuration
+
+- repo:
+    url: https://github.com/org/repo1
+    ref: v1.0.0
+
+- include:
+    patterns:
+      - "**/*"
+"#;
+        fs::write(&config_path, initial_config).unwrap();
+
+        append_repo_to_config(&config_path, "https://github.com/org/repo2", "v2.0.0").unwrap();
+
+        let content = fs::read_to_string(&config_path).unwrap();
+        // New repo should be inserted before include
+        assert!(content.contains("url: https://github.com/org/repo1"));
+        assert!(content.contains("url: https://github.com/org/repo2"));
+        assert!(content.contains("ref: v2.0.0"));
+        // Include should still be present
+        assert!(content.contains("- include:"));
+    }
+
+    #[test]
+    fn test_append_repo_to_config_without_include() {
+        let temp_dir = TempDir::new().unwrap();
+        let config_path = temp_dir.path().join(".common-repo.yaml");
+
+        // Create initial config without include section
+        let initial_config = r#"# common-repo configuration
+
+- repo:
+    url: https://github.com/org/repo1
+    ref: v1.0.0
+"#;
+        fs::write(&config_path, initial_config).unwrap();
+
+        append_repo_to_config(&config_path, "https://github.com/org/repo2", "v2.0.0").unwrap();
+
+        let content = fs::read_to_string(&config_path).unwrap();
+        assert!(content.contains("url: https://github.com/org/repo1"));
+        assert!(content.contains("url: https://github.com/org/repo2"));
+        assert!(content.contains("ref: v2.0.0"));
+    }
+}

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -16,6 +16,7 @@
 //! responsible for orchestrating the necessary operations, calling into the
 //! `common_repo` library to perform the core logic.
 
+pub mod add;
 pub mod apply;
 pub mod cache;
 pub mod check;

--- a/tests/cli_e2e_add.rs
+++ b/tests/cli_e2e_add.rs
@@ -1,0 +1,129 @@
+//! End-to-end tests for the `add` command.
+//!
+//! These tests invoke the actual CLI binary and validate the behavior of the
+//! `add` subcommand from a user's perspective.
+//!
+//! Note: The default `add` behavior prompts for confirmation when no config exists.
+//! Most tests use --quiet to skip the interactive prompt.
+
+use assert_cmd::cargo::cargo_bin_cmd;
+use assert_fs::prelude::*;
+use predicates::prelude::*;
+
+#[test]
+#[cfg_attr(not(feature = "integration-tests"), ignore)]
+fn test_add_quiet_creates_config() {
+    let temp = assert_fs::TempDir::new().unwrap();
+
+    // Add with --quiet to a directory without config
+    let mut cmd = cargo_bin_cmd!("common-repo");
+
+    cmd.current_dir(temp.path())
+        .arg("add")
+        .arg("--quiet")
+        .arg("rust-lang/rust-clippy")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Fetching tags from"))
+        .stdout(predicate::str::contains("✅ Created .common-repo.yaml"));
+
+    // Check that the config file was created with the repo
+    let config_file = temp.child(".common-repo.yaml");
+    config_file.assert(predicate::path::exists());
+    config_file.assert(predicate::str::contains(
+        "url: https://github.com/rust-lang/rust-clippy",
+    ));
+    config_file.assert(predicate::str::contains("ref:"));
+    config_file.assert(predicate::str::contains("- include:"));
+}
+
+#[test]
+#[cfg_attr(not(feature = "integration-tests"), ignore)]
+fn test_add_to_existing_config() {
+    let temp = assert_fs::TempDir::new().unwrap();
+    let config_file = temp.child(".common-repo.yaml");
+
+    // Create existing config
+    config_file
+        .write_str(
+            r#"# common-repo configuration
+
+- repo:
+    url: https://github.com/existing/repo
+    ref: v1.0.0
+
+- include:
+    patterns:
+      - "**/*"
+"#,
+        )
+        .unwrap();
+
+    // Add another repo
+    let mut cmd = cargo_bin_cmd!("common-repo");
+
+    cmd.current_dir(temp.path())
+        .arg("add")
+        .arg("rust-lang/rust-clippy")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Fetching tags from"))
+        .stdout(predicate::str::contains("✅ Added"));
+
+    // Verify both repos are in the config
+    config_file.assert(predicate::str::contains(
+        "url: https://github.com/existing/repo",
+    ));
+    config_file.assert(predicate::str::contains(
+        "url: https://github.com/rust-lang/rust-clippy",
+    ));
+}
+
+#[test]
+#[cfg_attr(not(feature = "integration-tests"), ignore)]
+fn test_add_github_shorthand_expansion() {
+    let temp = assert_fs::TempDir::new().unwrap();
+
+    let mut cmd = cargo_bin_cmd!("common-repo");
+
+    cmd.current_dir(temp.path())
+        .arg("add")
+        .arg("--quiet")
+        .arg("rust-lang/rust-clippy")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(
+            "Fetching tags from https://github.com/rust-lang/rust-clippy",
+        ));
+
+    // Check URL was expanded in config
+    let config_file = temp.child(".common-repo.yaml");
+    config_file.assert(predicate::str::contains(
+        "url: https://github.com/rust-lang/rust-clippy",
+    ));
+}
+
+#[test]
+fn test_add_without_uri_shows_error() {
+    let temp = assert_fs::TempDir::new().unwrap();
+
+    let mut cmd = cargo_bin_cmd!("common-repo");
+
+    cmd.current_dir(temp.path())
+        .arg("add")
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("required"));
+}
+
+#[test]
+fn test_add_help() {
+    let mut cmd = cargo_bin_cmd!("common-repo");
+
+    cmd.arg("add")
+        .arg("--help")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Add a repository"))
+        .stdout(predicate::str::contains("--quiet"));
+}

--- a/tests/snapshots/cli_snapshot_tests__main_help.snap
+++ b/tests/snapshots/cli_snapshot_tests__main_help.snap
@@ -1,6 +1,6 @@
 ---
 source: tests/cli_snapshot_tests.rs
-assertion_line: 28
+assertion_line: 37
 expression: normalized
 ---
 Common Repository - Manage repository configuration inheritance
@@ -8,6 +8,7 @@ Common Repository - Manage repository configuration inheritance
 Usage: common-repo [OPTIONS] <COMMAND>
 
 Commands:
+  add       Add a repository to the configuration file
   apply     Apply the .common-repo.yaml configuration to the current repository
   check     Check configuration validity and check for repository updates
   diff      Show differences between current files and configuration result


### PR DESCRIPTION
Add a new `add` command that allows users to quickly add repositories
to their .common-repo.yaml configuration. Features include:

- Auto-detection of latest semver tag from remote repository
- GitHub shorthand support (org/repo -> https://github.com/org/repo)
- Interactive confirmation when no config exists
- --quiet flag for non-interactive mode (creates minimal config)
- Intelligent YAML insertion (before include section)
- Warning for 0.x.x unstable versions

Includes unit tests, E2E tests, and documentation updates.