### PR TITLE
test(defer): add E2E tests for deferred operations (WIP)

### DIFF
--- a/context/current-task.json
+++ b/context/current-task.json
@@ -1,7 +1,7 @@
 {
-  "task": "fix-auto-merge-support",
+  "task": "update-docs",
   "plan": "context/source-declared-merge-impl.json",
-  "last_updated": "2026-01-01T09:55:00Z",
+  "last_updated": "2026-01-01T10:15:00Z",
   "status": "pending",
   "master_plan": "context/plan-of-plans.json",
   "context": {
@@ -18,23 +18,11 @@
     ],
     "current_subplan": "context/source-declared-merge-impl.json",
     "design_complete": "context/source-declared-merge.json",
-    "notes": "E2E tests created but 5/20 failing. Need to fix auto-merge support before tests pass.",
     "recently_completed": {
-      "task": "apply-deferred-ops",
+      "task": "fix-auto-merge-support",
       "plan": "source-declared-merge-impl",
-      "summary": "Added Operation::is_deferred() method and extract_deferred_operations() in discovery phase to prepend deferred ops before consumer with: operations"
+      "summary": "Fixed auto-merge support: added validation calls in validate command for all merge types, changed TomlMergeOp.path to Option<String>, fixed E2E tests to check stdout. All 20 defer tests now pass."
     },
-    "in_progress": {
-      "task": "add-e2e-tests",
-      "files_created": ["tests/cli_e2e_defer.rs"],
-      "test_results": "15 passing, 5 failing",
-      "blocked_by": "fix-auto-merge-support"
-    },
-    "blocking_issues": [
-      "TOML auto-merge not implemented in src/merge/toml.rs",
-      "validate command doesn't call operation.validate() methods",
-      "All supported merge types (yaml, json, toml, ini, markdown) must support auto-merge"
-    ],
     "skipped_task": {
       "task": "parse-top-level-ops",
       "reason": "Not needed - existing list format already handles root-level operators with proper ordering"

--- a/context/source-declared-merge-impl.json
+++ b/context/source-declared-merge-impl.json
@@ -2,7 +2,7 @@
   "plan_name": "Source-Declared Merge Implementation",
   "description": "Add defer flag to operators for source-declared merge behavior",
   "created": "2025-12-31",
-  "last_updated": "2026-01-01T09:55:00Z",
+  "last_updated": "2026-01-01T10:15:00Z",
   "parent_plan": "context/source-declared-merge.json",
   "design_document": "context/source-declared-merge-design.md",
   "approach": "Option 6: Add defer flag to existing operators, use existing list format for source configs",
@@ -88,10 +88,10 @@
     {
       "id": "add-e2e-tests",
       "name": "Add end-to-end tests",
-      "status": "in_progress",
+      "status": "complete",
       "priority": 4,
       "phase": "phase-2",
-      "blocked_by": "fix-auto-merge-support",
+      "blocked_by": null,
       "steps": [
         "Test: source repo with deferred markdown merge",
         "Test: consumer with: overrides deferred op",
@@ -106,26 +106,15 @@
         "tests/cli_e2e_defer.rs"
       ],
       "test_results": {
-        "passing": 15,
-        "failing": 5,
-        "failing_tests": [
-          "test_validate_auto_merge_conflicts_with_dest",
-          "test_validate_auto_merge_conflicts_with_source",
-          "test_validate_toml_merge_with_defer",
-          "test_validate_toml_merge_with_auto_merge",
-          "test_validate_multiple_deferred_operations"
-        ]
+        "passing": 20,
+        "failing": 0
       },
-      "blocking_issues": [
-        "TOML auto-merge not fully implemented in merge module",
-        "validate command doesn't call operation.validate() methods"
-      ],
       "complexity": "medium"
     },
     {
       "id": "fix-auto-merge-support",
       "name": "Fix auto-merge support for all merge types",
-      "status": "pending",
+      "status": "complete",
       "priority": 3.5,
       "phase": "phase-2",
       "blocked_by": null,
@@ -140,10 +129,11 @@
         "validate command catches auto-merge + source/dest conflicts",
         "All E2E defer tests pass"
       ],
-      "files_to_modify": [
-        "src/merge/toml.rs",
-        "src/merge/ini.rs (if needed)",
-        "src/commands/validate.rs"
+      "files_modified": [
+        "src/config.rs (changed TomlMergeOp.path from String to Option<String>)",
+        "src/merge/toml.rs (updated path handling for Option<String>)",
+        "src/commands/validate.rs (added validation calls for all merge operation types)",
+        "tests/cli_e2e_defer.rs (fixed tests to check stdout instead of stderr)"
       ],
       "complexity": "medium"
     },

--- a/src/commands/validate.rs
+++ b/src/commands/validate.rs
@@ -159,8 +159,39 @@ pub fn execute(args: ValidateArgs) -> Result<()> {
                     has_warnings = true;
                 }
             }
+            // Validate merge operations (source/dest requirements, auto-merge conflicts)
+            config::Operation::Yaml { yaml } => {
+                if let Err(e) = yaml.validate() {
+                    println!("❌ Invalid yaml merge operation {}: {}", idx, e);
+                    has_errors = true;
+                }
+            }
+            config::Operation::Json { json } => {
+                if let Err(e) = json.validate() {
+                    println!("❌ Invalid json merge operation {}: {}", idx, e);
+                    has_errors = true;
+                }
+            }
+            config::Operation::Toml { toml } => {
+                if let Err(e) = toml.validate() {
+                    println!("❌ Invalid toml merge operation {}: {}", idx, e);
+                    has_errors = true;
+                }
+            }
+            config::Operation::Ini { ini } => {
+                if let Err(e) = ini.validate() {
+                    println!("❌ Invalid ini merge operation {}: {}", idx, e);
+                    has_errors = true;
+                }
+            }
+            config::Operation::Markdown { markdown } => {
+                if let Err(e) = markdown.validate() {
+                    println!("❌ Invalid markdown merge operation {}: {}", idx, e);
+                    has_errors = true;
+                }
+            }
             _ => {
-                // Other operations don't have patterns to validate
+                // Other operations don't have additional validation
             }
         }
     }

--- a/src/merge/toml.rs
+++ b/src/merge/toml.rs
@@ -375,7 +375,7 @@ pub fn apply_toml_merge_operation(fs: &mut MemoryFS, op: &TomlMergeOp) -> Result
         message: format!("Failed to parse source TOML: {}", err),
     })?;
 
-    let path_str = &op.path;
+    let path_str = op.path.as_deref().unwrap_or("");
     let path = parse_toml_path(path_str);
     let target = navigate_toml_value(&mut dest_value, &path)?;
     let mode = op.get_array_mode();
@@ -587,7 +587,7 @@ serde = "1.0"
             let toml_op = crate::config::TomlMergeOp {
                 source: Some("source.toml".to_string()),
                 dest: Some("Cargo.toml".to_string()),
-                path: "".to_string(), // root level
+                path: None, // root level
                 ..Default::default()
             };
 
@@ -627,7 +627,7 @@ name = "mydb"
             let toml_op = crate::config::TomlMergeOp {
                 source: Some("config.toml".to_string()),
                 dest: Some("merged.toml".to_string()),
-                path: "server".to_string(),
+                path: Some("server".to_string()),
                 ..Default::default()
             };
 
@@ -664,7 +664,7 @@ items = ["old1", "old2"]
             let toml_op = crate::config::TomlMergeOp {
                 source: Some("source.toml".to_string()),
                 dest: Some("dest.toml".to_string()),
-                path: "".to_string(),
+                path: None,
                 array_mode: Some(crate::config::ArrayMergeMode::Replace),
                 ..Default::default()
             };
@@ -698,7 +698,7 @@ items = ["old1", "old2"]
             let toml_op = crate::config::TomlMergeOp {
                 source: Some("source.toml".to_string()),
                 dest: Some("dest.toml".to_string()),
-                path: "".to_string(),
+                path: None,
                 array_mode: Some(crate::config::ArrayMergeMode::Append),
                 ..Default::default()
             };
@@ -734,7 +734,7 @@ items = ["item1", "item4"]
             let toml_op = crate::config::TomlMergeOp {
                 source: Some("source.toml".to_string()),
                 dest: Some("dest.toml".to_string()),
-                path: "".to_string(),
+                path: None,
                 array_mode: Some(crate::config::ArrayMergeMode::AppendUnique),
                 ..Default::default()
             };
@@ -770,7 +770,7 @@ items = ["old1"]
             let toml_op = crate::config::TomlMergeOp {
                 source: Some("source.toml".to_string()),
                 dest: Some("dest.toml".to_string()),
-                path: "".to_string(),
+                path: None,
                 append: true,
                 ..Default::default()
             };
@@ -795,7 +795,7 @@ items = ["old1"]
             let op = TomlMergeOp {
                 source: Some("source.toml".to_string()),
                 dest: Some("new_dest.toml".to_string()),
-                path: "".to_string(),
+                path: None,
                 ..Default::default()
             };
 
@@ -862,7 +862,7 @@ existing = "kept"
             let op = TomlMergeOp {
                 source: Some("source.toml".to_string()),
                 dest: Some("dest.toml".to_string()),
-                path: "".to_string(),
+                path: None,
                 ..Default::default()
             };
 
@@ -903,7 +903,7 @@ name = "myserver"
             let op = TomlMergeOp {
                 source: Some("source.toml".to_string()),
                 dest: Some("dest.toml".to_string()),
-                path: "".to_string(),
+                path: None,
                 ..Default::default()
             };
 
@@ -936,7 +936,7 @@ existing = 1
             let op = TomlMergeOp {
                 source: Some("source.toml".to_string()),
                 dest: Some("dest.toml".to_string()),
-                path: "a.b.c".to_string(),
+                path: Some("a.b.c".to_string()),
                 ..Default::default()
             };
 
@@ -962,7 +962,7 @@ new_value = 42
             let op = TomlMergeOp {
                 source: Some("source.toml".to_string()),
                 dest: Some("dest.toml".to_string()),
-                path: "deeply.nested.path".to_string(),
+                path: Some("deeply.nested.path".to_string()),
                 ..Default::default()
             };
 
@@ -1000,7 +1000,7 @@ c = 3
             let op = TomlMergeOp {
                 source: Some("source.toml".to_string()),
                 dest: Some("dest.toml".to_string()),
-                path: "section2".to_string(),
+                path: Some("section2".to_string()),
                 ..Default::default()
             };
 
@@ -1038,7 +1038,7 @@ items = ["a", "b", "c"]
             let op = TomlMergeOp {
                 source: Some("source.toml".to_string()),
                 dest: Some("dest.toml".to_string()),
-                path: "".to_string(),
+                path: None,
                 array_mode: Some(ArrayMergeMode::Append),
                 ..Default::default()
             };
@@ -1071,7 +1071,7 @@ items = []
             let op = TomlMergeOp {
                 source: Some("source.toml".to_string()),
                 dest: Some("dest.toml".to_string()),
-                path: "".to_string(),
+                path: None,
                 array_mode: Some(ArrayMergeMode::Append),
                 ..Default::default()
             };
@@ -1110,7 +1110,7 @@ version = "4.0"
             let op = TomlMergeOp {
                 source: Some("source.toml".to_string()),
                 dest: Some("dest.toml".to_string()),
-                path: "".to_string(),
+                path: None,
                 array_mode: Some(ArrayMergeMode::Append),
                 ..Default::default()
             };
@@ -1142,7 +1142,7 @@ items = [false, 42]
             let op = TomlMergeOp {
                 source: Some("source.toml".to_string()),
                 dest: Some("dest.toml".to_string()),
-                path: "".to_string(),
+                path: None,
                 array_mode: Some(ArrayMergeMode::Append),
                 ..Default::default()
             };
@@ -1176,7 +1176,7 @@ host = "localhost"
             let op = TomlMergeOp {
                 source: Some("source.toml".to_string()),
                 dest: Some("dest.toml".to_string()),
-                path: "".to_string(),
+                path: None,
                 array_mode: Some(ArrayMergeMode::Append),
                 ..Default::default()
             };
@@ -1207,7 +1207,7 @@ items = [{name = "a"}, {name = "c"}]
             let op = TomlMergeOp {
                 source: Some("source.toml".to_string()),
                 dest: Some("dest.toml".to_string()),
-                path: "".to_string(),
+                path: None,
                 array_mode: Some(ArrayMergeMode::AppendUnique),
                 ..Default::default()
             };
@@ -1328,7 +1328,7 @@ items = 42
             let op = TomlMergeOp {
                 source: Some("source.toml".to_string()),
                 dest: Some("dest.toml".to_string()),
-                path: "".to_string(),
+                path: None,
                 array_mode: Some(ArrayMergeMode::Append),
                 ..Default::default()
             };
@@ -1375,7 +1375,7 @@ items = 42
             let op = TomlMergeOp {
                 source: Some("nonexistent.toml".to_string()),
                 dest: Some("dest.toml".to_string()),
-                path: "".to_string(),
+                path: None,
                 ..Default::default()
             };
 
@@ -1398,7 +1398,7 @@ items = 42
             let op = TomlMergeOp {
                 source: Some("source.toml".to_string()),
                 dest: Some("dest.toml".to_string()),
-                path: "".to_string(),
+                path: None,
                 ..Default::default()
             };
 
@@ -1448,7 +1448,7 @@ items = 42
             let op = TomlMergeOp {
                 source: Some("source.toml".to_string()),
                 dest: Some("dest.toml".to_string()),
-                path: "".to_string(),
+                path: None,
                 ..Default::default()
             };
 
@@ -1469,7 +1469,7 @@ items = 42
             let op = TomlMergeOp {
                 source: Some("source.toml".to_string()),
                 dest: Some("dest.toml".to_string()),
-                path: "".to_string(),
+                path: None,
                 ..Default::default()
             };
 
@@ -1504,7 +1504,7 @@ items = 42
             let op = TomlMergeOp {
                 source: Some("source.toml".to_string()),
                 dest: Some("dest.toml".to_string()),
-                path: "".to_string(),
+                path: None,
                 ..Default::default()
             };
 
@@ -1850,7 +1850,7 @@ items = 42
             let op = TomlMergeOp {
                 source: Some("source.toml".to_string()),
                 dest: Some("dest.toml".to_string()),
-                path: "".to_string(),
+                path: None,
                 preserve_comments: true,
                 ..Default::default()
             };
@@ -1874,7 +1874,7 @@ items = 42
             let op = TomlMergeOp {
                 source: Some("source.toml".to_string()),
                 dest: Some("dest.toml".to_string()),
-                path: "".to_string(),
+                path: None,
                 ..Default::default()
             };
 

--- a/src/operators.rs
+++ b/src/operators.rs
@@ -981,7 +981,7 @@ mod tests {
                     toml: crate::config::TomlMergeOp {
                         source: Some("s.toml".to_string()),
                         dest: Some("d.toml".to_string()),
-                        path: "/".to_string(),
+                        path: Some("/".to_string()),
                         ..Default::default()
                     },
                 },

--- a/src/phases/composite.rs
+++ b/src/phases/composite.rs
@@ -577,7 +577,7 @@ port = 8080
                 toml: TomlMergeOp {
                     source: Some("fragment.toml".to_string()),
                     dest: Some("config.toml".to_string()),
-                    path: "section".to_string(),
+                    path: Some("section".to_string()),
                     ..Default::default()
                 },
             };

--- a/src/phases/processing.rs
+++ b/src/phases/processing.rs
@@ -1253,7 +1253,7 @@ mod tests {
                 toml: TomlMergeOp {
                     source: Some("source.toml".to_string()),
                     dest: Some("dest.toml".to_string()),
-                    path: "section.key".to_string(),
+                    path: Some("section.key".to_string()),
                     preserve_comments: true,
                     ..Default::default()
                 },
@@ -1317,7 +1317,7 @@ mod tests {
                     toml: TomlMergeOp {
                         source: Some("s.toml".to_string()),
                         dest: Some("d.toml".to_string()),
-                        path: "key".to_string(),
+                        path: Some("key".to_string()),
                         ..Default::default()
                     },
                 },
@@ -1516,7 +1516,7 @@ mod tests {
                 toml: TomlMergeOp {
                     source: Some("source.toml".to_string()),
                     dest: Some("dest.toml".to_string()),
-                    path: "key".to_string(),
+                    path: Some("key".to_string()),
                     ..Default::default()
                 },
             };

--- a/tests/cli_e2e_defer.rs
+++ b/tests/cli_e2e_defer.rs
@@ -91,7 +91,7 @@ fn test_validate_auto_merge_conflicts_with_source() {
         .arg(config_file.path())
         .assert()
         .failure()
-        .stderr(predicate::str::contains("auto-merge").or(predicate::str::contains("source")));
+        .stdout(predicate::str::contains("auto-merge").or(predicate::str::contains("source")));
 }
 
 /// Test that auto-merge conflicts with explicit dest
@@ -119,7 +119,7 @@ fn test_validate_auto_merge_conflicts_with_dest() {
         .arg(config_file.path())
         .assert()
         .failure()
-        .stderr(predicate::str::contains("auto-merge").or(predicate::str::contains("dest")));
+        .stdout(predicate::str::contains("auto-merge").or(predicate::str::contains("dest")));
 }
 
 /// Test that validate accepts config with defer on json merge
@@ -658,7 +658,9 @@ fn test_check_with_deferred_operations() {
         .arg(config_file.path())
         .assert()
         .success()
-        .stdout(predicate::str::contains("Configuration loaded successfully"));
+        .stdout(predicate::str::contains(
+            "Configuration loaded successfully",
+        ));
 }
 
 // =============================================================================


### PR DESCRIPTION
Add tests/cli_e2e_defer.rs with 20 E2E tests for defer and auto-merge
features. 15 tests pass, 5 blocked on missing implementation:

- TOML auto-merge not implemented in merge module
- validate command doesn't call operation.validate() methods

Update plan with fix-auto-merge-support task to address blockers.