### PR TITLE
docs(defer): add defer/auto-merge documentation for source-declared merges

### DIFF
--- a/context/completed/source-declared-merge-impl.json
+++ b/context/completed/source-declared-merge-impl.json
@@ -2,7 +2,7 @@
   "plan_name": "Source-Declared Merge Implementation",
   "description": "Add defer flag to operators for source-declared merge behavior",
   "created": "2025-12-31",
-  "last_updated": "2026-01-01T10:15:00Z",
+  "last_updated": "2026-01-01T10:25:00Z",
   "parent_plan": "context/source-declared-merge.json",
   "design_document": "context/source-declared-merge-design.md",
   "approach": "Option 6: Add defer flag to existing operators, use existing list format for source configs",
@@ -140,7 +140,7 @@
     {
       "id": "update-docs",
       "name": "Update documentation",
-      "status": "pending",
+      "status": "complete",
       "priority": 5,
       "phase": "phase-2",
       "blocked_by": "add-e2e-tests",
@@ -153,7 +153,7 @@
         "Authoring guide documents defer flag",
         "Examples are clear"
       ],
-      "files_to_modify": [
+      "files_modified": [
         "docs/src/authoring-source-repos.md",
         "docs/src/configuration.md"
       ],

--- a/context/current-task.json
+++ b/context/current-task.json
@@ -1,8 +1,8 @@
 {
-  "task": "update-docs",
-  "plan": "context/source-declared-merge-impl.json",
-  "last_updated": "2026-01-01T10:15:00Z",
-  "status": "pending",
+  "task": null,
+  "plan": null,
+  "last_updated": "2026-01-01T10:25:00Z",
+  "status": "completed",
   "master_plan": "context/plan-of-plans.json",
   "context": {
     "completed_plans": [
@@ -14,18 +14,13 @@
       "context/completed/add-command.json",
       "context/completed/cr-alias.json",
       "context/completed/configuration-docs.json",
-      "context/completed/source-authoring-docs.json"
+      "context/completed/source-authoring-docs.json",
+      "context/completed/source-declared-merge-impl.json"
     ],
-    "current_subplan": "context/source-declared-merge-impl.json",
-    "design_complete": "context/source-declared-merge.json",
     "recently_completed": {
-      "task": "fix-auto-merge-support",
+      "task": "update-docs",
       "plan": "source-declared-merge-impl",
-      "summary": "Fixed auto-merge support: added validation calls in validate command for all merge types, changed TomlMergeOp.path to Option<String>, fixed E2E tests to check stdout. All 20 defer tests now pass."
-    },
-    "skipped_task": {
-      "task": "parse-top-level-ops",
-      "reason": "Not needed - existing list format already handles root-level operators with proper ordering"
+      "summary": "Added defer/auto-merge documentation to authoring-source-repos.md and configuration.md"
     }
   }
 }

--- a/context/plan-of-plans.json
+++ b/context/plan-of-plans.json
@@ -1,8 +1,8 @@
 {
   "plan_name": "Master Plan Tracker",
   "description": "High-level tracking of all active and pending plans",
-  "last_updated": "2025-12-31",
-  "active_plan": "context/source-declared-merge-impl.json",
+  "last_updated": "2026-01-01",
+  "active_plan": null,
   "next_plan": null,
   "plans": [
     {
@@ -85,13 +85,13 @@
     {
       "id": "source-declared-merge-impl",
       "name": "Source-Declared Merge Implementation",
-      "file": "context/source-declared-merge-impl.json",
-      "status": "in_progress",
+      "file": "context/completed/source-declared-merge-impl.json",
+      "status": "complete",
       "priority": 8,
       "category": "feature",
       "tasks_total": 5,
-      "tasks_complete": 0,
-      "notes": "defer flag approach - add defer: true to operators"
+      "tasks_complete": 5,
+      "notes": "defer flag approach - COMPLETED, ARCHIVED"
     }
   ],
   "deferred_reviews": [
@@ -140,9 +140,9 @@
   ],
   "summary": {
     "total_plans": 8,
-    "in_progress": 2,
+    "in_progress": 1,
     "pending": 0,
-    "complete": 6,
+    "complete": 7,
     "deferred_reviews": 8
   },
   "notes": [

--- a/docs/src/configuration.md
+++ b/docs/src/configuration.md
@@ -265,6 +265,37 @@ This operator validates but does not install tools. Warnings are issued for miss
 
 Merge operators intelligently combine configuration fragments into destination files.
 
+### Source-Declared Merge (defer/auto-merge)
+
+All merge operators support two additional options for source-declared merge behavior:
+
+| Option | Type | Description |
+|--------|------|-------------|
+| `auto-merge` | string | Shorthand: sets source=dest to this value and implies defer=true |
+| `defer` | bool | When true, this operation only runs when repo is used as a source |
+
+**`auto-merge`** is the preferred syntax when the source and destination filenames are the same:
+
+```yaml
+# In source repo's .common-repo.yaml
+- markdown:
+    auto-merge: CLAUDE.md     # source=dest=CLAUDE.md, defer=true
+    section: "## Rules"
+    append: true
+```
+
+**`defer: true`** is used when source and destination paths differ:
+
+```yaml
+- yaml:
+    source: config/base.yaml
+    dest: config.yaml
+    path: settings
+    defer: true               # Only applies when repo is inherited
+```
+
+See [Source-Declared Merge Behavior](authoring-source-repos.md#source-declared-merge-behavior) for detailed usage.
+
 ### `yaml` - Merge YAML Files
 
 ```yaml
@@ -277,10 +308,14 @@ Merge operators intelligently combine configuration fragments into destination f
 
 | Option | Required | Default | Description |
 |--------|----------|---------|-------------|
-| `source` | Yes | - | Source fragment file |
-| `dest` | Yes | - | Destination file |
+| `source` | Yes* | - | Source fragment file |
+| `dest` | Yes* | - | Destination file |
+| `auto-merge` | No | - | Shorthand: sets source=dest, implies defer=true |
+| `defer` | No | false | Only apply when repo is used as a source |
 | `path` | No | root | Dot-notation path to merge at |
 | `append` | No | false | Append to lists instead of replace |
+
+*Either `source`+`dest` or `auto-merge` is required
 
 #### Examples
 
@@ -323,11 +358,15 @@ Merge operators intelligently combine configuration fragments into destination f
 
 | Option | Required | Default | Description |
 |--------|----------|---------|-------------|
-| `source` | Yes | - | Source fragment file |
-| `dest` | Yes | - | Destination file |
+| `source` | Yes* | - | Source fragment file |
+| `dest` | Yes* | - | Destination file |
+| `auto-merge` | No | - | Shorthand: sets source=dest, implies defer=true |
+| `defer` | No | false | Only apply when repo is used as a source |
 | `path` | No | root | Dot-notation path to merge at |
 | `append` | No | false | Append to arrays instead of replace |
 | `position` | No | end | Where to append: `start` or `end` |
+
+*Either `source`+`dest` or `auto-merge` is required
 
 #### Examples
 
@@ -362,11 +401,15 @@ Merge operators intelligently combine configuration fragments into destination f
 
 | Option | Required | Default | Description |
 |--------|----------|---------|-------------|
-| `source` | Yes | - | Source fragment file |
-| `dest` | Yes | - | Destination file |
+| `source` | Yes* | - | Source fragment file |
+| `dest` | Yes* | - | Destination file |
+| `auto-merge` | No | - | Shorthand: sets source=dest, implies defer=true |
+| `defer` | No | false | Only apply when repo is used as a source |
 | `path` | No | root | Dot-notation path to merge at |
 | `append` | No | false | Append to arrays instead of replace |
 | `preserve-comments` | No | true | Keep comments in output |
+
+*Either `source`+`dest` or `auto-merge` is required
 
 #### Examples
 
@@ -391,11 +434,15 @@ Merge operators intelligently combine configuration fragments into destination f
 
 | Option | Required | Default | Description |
 |--------|----------|---------|-------------|
-| `source` | Yes | - | Source fragment file |
-| `dest` | Yes | - | Destination file |
+| `source` | Yes* | - | Source fragment file |
+| `dest` | Yes* | - | Destination file |
+| `auto-merge` | No | - | Shorthand: sets source=dest, implies defer=true |
+| `defer` | No | false | Only apply when repo is used as a source |
 | `section` | No | - | INI section to merge into |
 | `append` | No | false | Append values instead of replace |
 | `allow-duplicates` | No | false | Allow duplicate keys |
+
+*Either `source`+`dest` or `auto-merge` is required
 
 #### Examples
 
@@ -420,13 +467,17 @@ Merge operators intelligently combine configuration fragments into destination f
 
 | Option | Required | Default | Description |
 |--------|----------|---------|-------------|
-| `source` | Yes | - | Source fragment file |
-| `dest` | Yes | - | Destination file |
+| `source` | Yes* | - | Source fragment file |
+| `dest` | Yes* | - | Destination file |
+| `auto-merge` | No | - | Shorthand: sets source=dest, implies defer=true |
+| `defer` | No | false | Only apply when repo is used as a source |
 | `section` | No | - | Heading to merge under |
 | `level` | No | 2 | Heading level (1-6) |
 | `append` | No | false | Append to section |
 | `position` | No | end | Where to insert: `start` or `end` |
 | `create-section` | No | false | Create section if missing |
+
+*Either `source`+`dest` or `auto-merge` is required
 
 #### Examples
 


### PR DESCRIPTION
- Add Source-Declared Merge Behavior section to authoring-source-repos.md
- Document auto-merge shorthand and defer: true syntax with examples
- Add defer/auto-merge options to all merge operators in configuration.md
- Archive completed source-declared-merge-impl.json plan