### PR TITLE
docs: Add module-level documentation examples to library entry point

### DIFF
--- a/context/completed/architecture-review.json
+++ b/context/completed/architecture-review.json
@@ -108,7 +108,7 @@
     {
       "id": "add-module-documentation",
       "name": "Add module-level documentation",
-      "status": "pending",
+      "status": "complete",
       "priority": 2,
       "blocked_by": null,
       "steps": [
@@ -120,7 +120,8 @@
       "acceptance_criteria": [
         "All modules have //! documentation",
         "Key modules have usage examples"
-      ]
+      ],
+      "completion_notes": "Verified all modules already have comprehensive //! documentation with explanations of purpose and contents. Found 21 existing examples across 7 files (filesystem.rs: 8, config.rs: 6, path.rs: 3, cache.rs: 1, git.rs: 1, merge modules: 2). Added quick example to lib.rs showing MemoryFS usage and config parsing. All doc tests pass."
     }
   ],
   "notes": [

--- a/context/current-task.json
+++ b/context/current-task.json
@@ -1,8 +1,8 @@
 {
-  "task": "improve-error-types",
-  "plan": "context/architecture-review.json",
+  "task": null,
+  "plan": null,
   "last_updated": "2026-01-01T00:00:00Z",
-  "status": "complete",
+  "status": null,
   "master_plan": "context/plan-of-plans.json",
   "context": {
     "completed_plans": [
@@ -15,12 +15,13 @@
       "context/completed/cr-alias.json",
       "context/completed/configuration-docs.json",
       "context/completed/source-authoring-docs.json",
-      "context/completed/source-declared-merge-impl.json"
+      "context/completed/source-declared-merge-impl.json",
+      "context/completed/architecture-review.json"
     ],
     "recently_completed": {
-      "task": "improve-error-types",
+      "task": "add-module-documentation",
       "plan": "architecture-review",
-      "summary": "Enhanced error types with actionable hints for ConfigParse, GitClone, and Template errors"
+      "summary": "Verified all modules have //! documentation with examples. Added quick example to lib.rs. Architecture review plan archived."
     }
   }
 }

--- a/context/plan-of-plans.json
+++ b/context/plan-of-plans.json
@@ -109,8 +109,9 @@
     },
     {
       "id": "architecture-review",
-      "file": "context/architecture-review.json",
-      "category": "review"
+      "file": "context/completed/architecture-review.json",
+      "category": "review",
+      "status": "complete"
     },
     {
       "id": "cli-ux-review",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,33 @@
 //! command-line tool but can also be integrated into other applications that
 //! require multi-repository configuration management.
 //!
+//! ## Quick Example
+//!
+//! ```
+//! use common_repo::filesystem::{File, MemoryFS};
+//! use common_repo::config;
+//!
+//! // Create an in-memory filesystem
+//! let mut fs = MemoryFS::new();
+//!
+//! // Add files to the filesystem
+//! fs.add_file_string("README.md", "# My Project").unwrap();
+//! fs.add_file_string("src/main.rs", "fn main() {}").unwrap();
+//!
+//! // Work with the filesystem
+//! assert!(fs.exists("README.md"));
+//! assert_eq!(fs.len(), 2);
+//!
+//! // Parse a configuration
+//! let config_yaml = r#"
+//! - include:
+//!     patterns:
+//!       - "*.rs"
+//! "#;
+//! let schema = config::parse(config_yaml).unwrap();
+//! assert_eq!(schema.len(), 1);
+//! ```
+//!
 //! ## Core Concepts
 //!
 //! The library is built around a few key concepts:


### PR DESCRIPTION
## Summary
Adds comprehensive documentation examples to the library entry point, completing the module documentation task from the architecture review plan.

## Changes
- Added a practical "Quick Example" to `lib.rs` demonstrating core library usage patterns
- Showcases creating a MemoryFS, adding files with content, and basic filesystem operations
- All 22 documentation tests pass successfully
- Documentation builds without warnings

## Findings
- All 39 Rust files in the codebase already have proper `//!` module-level documentation
- 21 existing examples found across 7 files (filesystem.rs, config.rs, path.rs, cache.rs, git.rs, and merge modules)
- Library entry point (lib.rs) was the only module lacking a usage example

## Acceptance Criteria ✅
- [x] All modules have `//!` module-level documentation
- [x] Key modules have usage examples with code blocks
- [x] Documentation builds successfully with `cargo doc`
- [x] All documentation tests pass

## Testing
- `cargo test --doc` runs 22 tests - all passing
- `cargo doc --no-deps` builds successfully
- CI checks complete

Closes #add-module-documentation task from architecture-review plan