### PR TITLE
docs: fix documentation gaps and improve feature discoverability

### DIFF
--- a/docs/src/getting-started.md
+++ b/docs/src/getting-started.md
@@ -31,6 +31,9 @@ curl -fsSL https://raw.githubusercontent.com/common-repo/common-repo/main/instal
 
 # Skip creating the 'cr' alias
 SKIP_ALIAS=1 curl -fsSL https://raw.githubusercontent.com/common-repo/common-repo/main/install.sh | sh
+
+# Use GitHub token to avoid API rate limits (useful in CI)
+GITHUB_TOKEN=ghp_xxx curl -fsSL https://raw.githubusercontent.com/common-repo/common-repo/main/install.sh | sh
 ```
 
 ### From Pre-built Binaries


### PR DESCRIPTION
Fix incorrect default values:
- TOML preserve-comments: true -> false
- JSON/Markdown position: "end" -> unset (only applies when append=true)
- Exit codes: remove undocumented codes 2/3, document diff special behavior

Add missing documentation:
- array_mode option for YAML/TOML merge operators (replace/append/append_unique)
- Path navigation syntax (bracket notation, array indices, escaping)
- Cache command options (--verbose, --json, --all, --unused, --older-than, etc.)
- --log-level off value
- GITHUB_TOKEN env var for install.sh
- JSON output schema for cache list --json

Improve discoverability:
- Add Path Syntax section with comprehensive examples
- Add Array Merge Modes table
- Document cache clean duration format with all aliases
- Add diff command exit code behavior for scripting