### PR TITLE
docs: add AI writing patterns reference to CLAUDE.md and master plan

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -288,6 +288,7 @@ Breaking changes: `feat!: description` or `BREAKING CHANGE:` in footer
 ## Documentation Style Guide
 
 - Follow [Rustdoc guide](https://doc.rust-lang.org/rustdoc/how-to-write-documentation.html), [Rust API Guidelines](https://rust-lang.github.io/api-guidelines/), and [std-dev style guide](https://std-dev-guide.rust-lang.org/development/how-to-write-documentation.html)
+- **Avoid AI writing patterns** - See `context/ai-writing-patterns.md` for comprehensive list of phrases, words, and structures to avoid
 - Link to files/documentation appropriately
 - No emojis or hype language
 - No specific numbers that will change (versions, coverage percentages)

--- a/context/master-plan.json
+++ b/context/master-plan.json
@@ -59,10 +59,20 @@
       "description": "Scan and rewrite docs to remove AI-generated patterns, make them read like developer-written docs"
     },
     {
+      "id": "prose-linter",
+      "name": "Build Prose Linter Tool",
+      "status": "in_progress",
+      "priority": 6,
+      "blocked_by": "ai-isms-removal",
+      "plan_file": "context/plan-prose-linter.json",
+      "estimated_sessions": 1,
+      "description": "Custom Rust tool (cargo xtask check-prose) to detect AI writing patterns in docs, code comments, and all text content"
+    },
+    {
       "id": "competitive-research",
       "name": "Competitive Analysis for Feature Prioritization",
       "status": "pending",
-      "priority": 6,
+      "priority": 7,
       "blocked_by": null,
       "plan_file": "context/plan-competitive-research.json",
       "estimated_sessions": 2,
@@ -96,6 +106,12 @@
     },
     {
       "phase": 5,
+      "name": "Sequential: Prose Linter Tool",
+      "plans": ["prose-linter"],
+      "notes": "Build tool to enforce ai-writing-patterns.md automatically"
+    },
+    {
+      "phase": 6,
       "name": "Parallel Track B: Research",
       "plans": ["competitive-research"],
       "notes": "Can run anytime - independent of other work"


### PR DESCRIPTION
- Add reference to context/ai-writing-patterns.md in Documentation Style Guide
- Add prose-linter plan to master-plan.json (phase 5)
- Update execution_order to include new phase