### PR TITLE
feat(update): add --filter flag for selective source updates

### DIFF
--- a/context/plan-update-filter.json
+++ b/context/plan-update-filter.json
@@ -12,7 +12,7 @@
     {
       "id": "add-strip-url-scheme",
       "name": "Add strip_url_scheme helper to src/path.rs",
-      "status": "pending",
+      "status": "complete",
       "priority": 1,
       "blocked_by": null,
       "output_file": "src/path.rs",
@@ -32,7 +32,7 @@
     {
       "id": "add-filter-arg",
       "name": "Add --filter argument to UpdateArgs",
-      "status": "pending",
+      "status": "complete",
       "priority": 2,
       "blocked_by": null,
       "output_file": "src/commands/update.rs",
@@ -51,7 +51,7 @@
     {
       "id": "implement-filter-logic",
       "name": "Implement filter matching in execute()",
-      "status": "pending",
+      "status": "complete",
       "priority": 3,
       "blocked_by": ["add-strip-url-scheme", "add-filter-arg"],
       "output_file": "src/commands/update.rs",
@@ -72,10 +72,10 @@
     {
       "id": "add-unit-tests",
       "name": "Add unit tests for filter logic",
-      "status": "pending",
+      "status": "complete",
       "priority": 4,
       "blocked_by": ["implement-filter-logic"],
-      "output_file": "src/commands/update.rs",
+      "output_file": "src/version.rs",
       "steps": [
         "Add tests module if not present",
         "Test build_match_target with url only",
@@ -87,13 +87,13 @@
         "Tests cover url-only and url+path cases",
         "Tests verify scheme stripping",
         "Tests verify OR logic for multiple patterns",
-        "cargo test update:: passes"
+        "cargo test version:: passes"
       ]
     },
     {
       "id": "add-e2e-test",
       "name": "Add E2E test for filtered update",
-      "status": "pending",
+      "status": "complete",
       "priority": 5,
       "blocked_by": ["implement-filter-logic"],
       "output_file": "tests/cli_e2e_update.rs",
@@ -112,7 +112,7 @@
     {
       "id": "update-docs",
       "name": "Update documentation for --filter flag",
-      "status": "pending",
+      "status": "complete",
       "priority": 6,
       "blocked_by": ["implement-filter-logic"],
       "output_file": "docs/src/update-workflow.md",
@@ -130,7 +130,7 @@
     {
       "id": "final-validation",
       "name": "Run full CI checks",
-      "status": "pending",
+      "status": "complete",
       "priority": 7,
       "blocked_by": ["add-unit-tests", "add-e2e-test", "update-docs"],
       "output_file": null,

--- a/docs/src/update-workflow.md
+++ b/docs/src/update-workflow.md
@@ -67,6 +67,33 @@ For scripting or CI, skip the confirmation prompt:
 common-repo update --yes
 ```
 
+### Selective Updates
+
+Update only specific sources using glob patterns:
+
+```bash
+# Update repos matching a pattern
+common-repo update --filter "github.com/org/*"
+
+# Update multiple patterns (OR logic)
+common-repo update --filter "*/*/ci-*" --filter "*/*/linter-*"
+
+# Combine with other flags
+common-repo update --filter "github.com/org/*" --latest --dry-run
+```
+
+Patterns match against the repository URL (with scheme stripped) combined with the optional path. For example:
+
+| Config | Match Target |
+|--------|--------------|
+| `url: https://github.com/org/repo` | `github.com/org/repo` |
+| `url: https://github.com/org/monorepo`, `path: configs/eslint` | `github.com/org/monorepo/configs/eslint` |
+
+Pattern examples:
+- `github.com/org/*` - repos under a specific org
+- `*/*/ci-*` - any repo with "ci-" prefix
+- `github.com/**` - all GitHub repos
+
 ## Complete Example
 
 A typical update session:

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -238,6 +238,7 @@ mod tests {
                 latest: false,
                 yes: false,
                 dry_run: true, // Use dry run to avoid actual changes
+                filter: vec![],
             }),
             color: "auto".to_string(),
             log_level: "info".to_string(),


### PR DESCRIPTION
## Summary

- Add `--filter <GLOB>` flag to `update` command for selective source updates
- Patterns match against repository URL (scheme stripped) combined with optional path
- Multiple `--filter` flags use OR logic (match any pattern)

## Changes

- `src/path.rs`: Add `strip_url_scheme()` helper function
- `src/version.rs`: Add `check_updates_filtered()` with `FilteredUpdateResult`
- `src/commands/update.rs`: Add `--filter` argument and filtering logic
- `tests/cli_e2e_update.rs`: Add 5 E2E tests for filter functionality
- `docs/src/update-workflow.md`: Document selective updates with examples

## Test plan

- [x] Unit tests for `strip_url_scheme()` in path.rs
- [x] Unit tests for `build_match_target()` and `matches_filter()` in version.rs
- [x] E2E tests for `--filter` flag behavior
- [x] All 875 tests pass
- [x] CI checks pass (fmt, clippy, pre-commit)

🤖 Generated with [Claude Code](https://claude.ai/code)