### PR TITLE
perf: add release profile optimizations

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,3 +58,9 @@ path = "src/main.rs"
 [[test]]
 name = "schema_parsing_test"
 harness = false
+
+# Optimize release builds for performance
+[profile.release]
+lto = true          # Link-time optimization for better performance
+codegen-units = 1   # Single codegen unit for maximum optimization
+strip = true        # Strip symbols for smaller binaries

--- a/context/current-task.json
+++ b/context/current-task.json
@@ -1,6 +1,6 @@
 {
-  "task": null,
-  "plan": null,
+  "task": "add-release-profile-optimizations",
+  "plan": "context/performance-review.json",
   "last_updated": "2026-01-07",
-  "description": "No active task - plan-update-filter completed and archived"
+  "description": "Add [profile.release] optimizations to Cargo.toml for better performance"
 }

--- a/context/performance-review.json
+++ b/context/performance-review.json
@@ -1,18 +1,18 @@
 {
   "plan_name": "Performance Review",
   "description": "Improve performance practices to meet OSS best practices",
-  "last_updated": "2025-12-03",
+  "last_updated": "2026-01-07",
   "audit_summary": {
-    "current_score": "1/10",
-    "pass": [],
+    "current_score": "2/10",
+    "pass": ["9.3 Release profile optimization"],
     "partial": ["9.9 Critical paths (rayon for parallel cloning implemented)"],
-    "fail": ["9.1 Benchmarks", "9.2 Benchmarks in CI", "9.3 Release profile optimization", "9.4 Profiling documentation", "9.5 Memory tracking", "9.6 Performance regression detection", "9.7 Size-optimized profile", "9.8 Compile time optimization", "9.10 Performance documentation"]
+    "fail": ["9.1 Benchmarks", "9.2 Benchmarks in CI", "9.4 Profiling documentation", "9.5 Memory tracking", "9.6 Performance regression detection", "9.7 Size-optimized profile", "9.8 Compile time optimization", "9.10 Performance documentation"]
   },
   "tasks": [
     {
       "id": "add-release-profile-optimizations",
       "name": "Add release profile optimizations",
-      "status": "pending",
+      "status": "complete",
       "priority": 1,
       "blocked_by": null,
       "steps": [


### PR DESCRIPTION
## Summary
- Add `[profile.release]` section to Cargo.toml with LTO, single codegen-unit, and symbol stripping
- Optimizes release builds for better runtime performance and smaller binaries
- Binary size: 3.97 MB with optimizations applied

## Test plan
- [x] Release build completes successfully (`cargo build --release`)
- [x] All 875 tests pass
- [x] Binary is functional

🤖 Generated with [Claude Code](https://claude.com/claude-code)