### PR TITLE
fix(test): handle conditional pre-commit CLI prompt in interactive test

### DIFF
--- a/context/current-task.json
+++ b/context/current-task.json
@@ -1,21 +1,7 @@
 {
-  "task": "investigate-flaky-precommit-test",
+  "task": null,
   "plan": null,
   "last_updated": "2026-01-07",
-  "description": "Investigate test_interactive_precommit_config_generation timeout - determine if slow or hanging on interactive input",
-  "details": {
-    "test_file": "tests/cli_e2e_init_interactive.rs",
-    "test_name": "test_interactive_precommit_config_generation",
-    "symptom": "Times out after 30 seconds in integration tests",
-    "hypothesis": [
-      "Test is hanging waiting for interactive input that never comes",
-      "Test is actually slow due to network or setup"
-    ],
-    "investigation_steps": [
-      "Read the test implementation to understand what it does",
-      "Check if rexpect is properly handling all prompts",
-      "Look for missing expect() calls that would cause hangs",
-      "Check if there are conditional prompts not being handled"
-    ]
-  }
+  "description": null,
+  "details": null
 }

--- a/tests/cli_e2e_init_interactive.rs
+++ b/tests/cli_e2e_init_interactive.rs
@@ -480,6 +480,22 @@ fn test_interactive_precommit_config_generation() {
         .exp_string("Created .pre-commit-config.yaml")
         .expect("Should see pre-commit config created");
 
+    // If prek or pre-commit is installed, there will be a second prompt asking
+    // "Run 'prek install' to set up git hooks?" - decline it to avoid side effects.
+    // If not installed, we'll see the "No pre-commit CLI found" message instead.
+    // Use exp_regex to match either case, then respond accordingly.
+    let result = session
+        .exp_regex("(Run '(prek|pre-commit) install'|No pre-commit CLI found)")
+        .expect("Should see either install prompt or CLI not found message");
+
+    // If we matched the install prompt, decline it
+    if result.1.contains("Run '") {
+        session
+            .send_line("n")
+            .expect("Failed to decline hook install");
+    }
+    // Otherwise, we saw "No pre-commit CLI found" and can continue
+
     // Wait for final success message
     session
         .exp_string("Created .common-repo.yaml")


### PR DESCRIPTION
## Summary
- Fixed `test_interactive_precommit_config_generation` timing out on machines with `prek` or `pre-commit` installed
- The test now handles both cases: declining the install prompt when a CLI is found, or continuing when "No pre-commit CLI found" is shown

## Root Cause
When accepting pre-commit setup, `setup_precommit_hooks()` prompts "Run 'prek install' to set up git hooks?" if a CLI is detected. The test wasn't handling this conditional second prompt, causing it to hang waiting for input that never came.

## Test plan
- [x] `test_interactive_precommit_config_generation` passes locally (was timing out)
- [x] All 8 interactive init tests pass
- [x] Full test suite (875 tests) passes

🤖 Generated with [Claude Code](https://claude.ai/code)