### PR TITLE
docs: rename 'source repo' to 'upstream repo'

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Full documentation is available at [common-repo.github.io/common-repo](https://c
 | [CLI Reference](docs/src/cli.md) | Command documentation |
 | [Recipes](docs/src/recipes.md) | Common patterns |
 | [Troubleshooting](docs/src/troubleshooting.md) | Common issues and solutions |
-| [Authoring Source Repos](docs/src/authoring-source-repos.md) | Create your own source repos |
+| [Authoring Upstream Repos](docs/src/authoring-upstream-repos.md) | Create your own upstream repos |
 
 ## Quick Start
 

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -13,9 +13,9 @@
 - [Recipes](recipes.md)
 - [Troubleshooting](troubleshooting.md)
 
-# For Source Repo Authors
+# For Upstream Repo Authors
 
-- [Authoring Source Repositories](authoring-source-repos.md)
+- [Authoring Upstream Repositories](authoring-upstream-repos.md)
 
 # Reference
 

--- a/docs/src/authoring-upstream-repos.md
+++ b/docs/src/authoring-upstream-repos.md
@@ -1,21 +1,21 @@
-# Authoring Source Repositories
+# Authoring Upstream Repositories
 
-This guide explains how to create and maintain source repositories that other projects can inherit from using common-repo.
+This guide explains how to create and maintain upstream repositories that other projects can inherit from using common-repo.
 
-## What is a Source Repository?
+## What is an Upstream Repository?
 
-A **source repository** contains configuration files, templates, and standards that other repositories (consumers) can inherit—essentially a library of reusable project configurations.
+An **upstream repository** contains configuration files, templates, and standards that other repositories (consumers) can inherit—essentially a library of reusable project configurations.
 
-**Source repository** vs **consumer repository**:
+**Upstream repository** vs **consumer repository**:
 
-| Aspect | Source Repository | Consumer Repository |
+| Aspect | Upstream Repository | Consumer Repository |
 |--------|-------------------|---------------------|
-| Purpose | Provides files for others to inherit | Uses files from source repos |
+| Purpose | Provides files for others to inherit | Uses files from upstream repos |
 | Audience | Maintainers of shared standards | Individual projects |
 | Config file | Optional `.common-repo.yaml` | Required `.common-repo.yaml` |
-| Versioning | Semantic versioning with Git tags | References source repo versions |
+| Versioning | Semantic versioning with Git tags | References upstream repo versions |
 
-**Common use cases for source repositories:**
+**Common use cases for upstream repositories:**
 
 - Organization-wide coding standards (linting, formatting rules)
 - CI/CD workflow templates (GitHub Actions, GitLab CI)
@@ -25,12 +25,12 @@ A **source repository** contains configuration files, templates, and standards t
 
 ## Getting Started
 
-### Minimal Source Repository Structure
+### Minimal Upstream Repository Structure
 
-A source repository can be as simple as a directory with files to share:
+A upstream repository can be as simple as a directory with files to share:
 
 ```
-my-source-repo/
+my-upstream-repo/
 ├── .github/
 │   └── workflows/
 │       └── ci.yml
@@ -43,13 +43,13 @@ No special configuration is required. Consumers reference your repository direct
 ```yaml
 # Consumer's .common-repo.yaml
 - repo:
-    url: https://github.com/your-org/my-source-repo
+    url: https://github.com/your-org/my-upstream-repo
     ref: v1.0.0
 ```
 
-### Optional: Configuration in Source Repos
+### Optional: Configuration in Upstream Repos
 
-Source repositories can include their own `.common-repo.yaml` to inherit from other sources, creating an inheritance chain:
+Upstream repositories can include their own `.common-repo.yaml` to inherit from other upstreams, creating an inheritance chain:
 
 ```
 org-base/          # Base standards
@@ -57,13 +57,13 @@ org-base/          # Base standards
       └── my-app/  # Consumer (inherits rust-base)
 ```
 
-## Source-Declared File Filtering
+## Upstream-Declared File Filtering
 
-Source repositories can define their "public API" by specifying which files are exposed to consumers. This is useful when a repository contains internal files that should not be inherited.
+Upstream repositories can define their "public API" by specifying which files are exposed to consumers. This is useful when a repository contains internal files that should not be inherited.
 
-### Filtering Operations in Source Repos
+### Filtering Operations in Upstream Repos
 
-Source repos can use these operations to control which files consumers receive:
+Upstream repos can use these operations to control which files consumers receive:
 
 | Operation | Purpose |
 |-----------|---------|
@@ -73,10 +73,10 @@ Source repos can use these operations to control which files consumers receive:
 
 ### Example: Exposing Only Public Files
 
-A source repo with internal test fixtures that should not be inherited:
+An upstream repo with internal test fixtures that should not be inherited:
 
 ```yaml
-# Source repo: .common-repo.yaml
+# Upstream repo: .common-repo.yaml
 - include:
     patterns:
       - "templates/**"
@@ -89,10 +89,10 @@ Consumers automatically receive only the declared public files.
 
 ### Example: Hiding Internal Files
 
-A source repo that exposes everything except internal directories:
+An upstream repo that exposes everything except internal directories:
 
 ```yaml
-# Source repo: .common-repo.yaml
+# Upstream repo: .common-repo.yaml
 - exclude:
     patterns:
       - "internal/**"
@@ -102,10 +102,10 @@ A source repo that exposes everything except internal directories:
 
 ### Example: Renaming Template Files
 
-A source repo that provides templates with a different naming convention:
+An upstream repo that provides templates with a different naming convention:
 
 ```yaml
-# Source repo: .common-repo.yaml
+# Upstream repo: .common-repo.yaml
 - rename:
     - from: "templates/(.*)\\.template"
       to: "$1"
@@ -117,25 +117,25 @@ This transforms `templates/config.yaml.template` to `config.yaml` in consumers.
 
 Operations are applied in this order:
 
-1. **Source filtering** (include/exclude/rename from source's config)
-2. **Source merge declarations** (deferred merge operations)
+1. **Upstream filtering** (include/exclude/rename from upstream's config)
+2. **Upstream merge declarations** (deferred merge operations)
 3. **Consumer's with: clause** (further filtering/transforms by consumer)
 
-This ensures source repos control their exposed files, while consumers can further filter (but not expand) what they receive.
+This ensures upstream repos control their exposed files, while consumers can further filter (but not expand) what they receive.
 
 ### Config File Auto-Exclusion
 
-Source repository config files (`.common-repo.yaml` and `.commonrepo.yaml`) are automatically excluded and never copied to consumers. This prevents source configs from overwriting consumer configs.
+Upstream repository config files (`.common-repo.yaml` and `.commonrepo.yaml`) are automatically excluded and never copied to consumers. This prevents upstream configs from overwriting consumer configs.
 
-## Source-Declared Merge Behavior
+## Upstream-Declared Merge Behavior
 
-By default, files from source repositories overwrite files in consumer repositories. However, source authors often know best how their files should integrate. The **defer** mechanism allows source repos to declare merge behavior that automatically applies when consumers inherit from them.
+By default, files from upstream repositories overwrite files in consumer repositories. However, upstream authors often know best how their files should integrate. The **defer** mechanism allows upstream repos to declare merge behavior that automatically applies when consumers inherit from them.
 
-### When to Use Source-Declared Merges
+### When to Use Upstream-Declared Merges
 
-Use source-declared merges when:
+Use upstream-declared merges when:
 
-- Your source provides partial content meant to augment consumer files (e.g., additional CLAUDE.md rules)
+- Your upstream provides partial content meant to augment consumer files (e.g., additional CLAUDE.md rules)
 - Files need intelligent merging rather than overwriting (e.g., shared dependencies in Cargo.toml)
 - You want to reduce boilerplate in consumer configurations
 
@@ -144,7 +144,7 @@ Use source-declared merges when:
 **1. `auto-merge` - When source and destination have the same filename (most common):**
 
 ```yaml
-# Source repo: .common-repo.yaml
+# Upstream repo: .common-repo.yaml
 - markdown:
     auto-merge: CLAUDE.md
     section: "## Inherited Rules"
@@ -156,7 +156,7 @@ This is shorthand for: source=CLAUDE.md, dest=CLAUDE.md, defer=true.
 **2. `defer: true` - When source and destination paths differ:**
 
 ```yaml
-# Source repo: .common-repo.yaml
+# Upstream repo: .common-repo.yaml
 - yaml:
     source: config/labels.yaml
     dest: kubernetes.yaml
@@ -169,7 +169,7 @@ This is shorthand for: source=CLAUDE.md, dest=CLAUDE.md, defer=true.
 An organization wants all repos to inherit coding guidelines:
 
 ```yaml
-# Source repo: org-standards/.common-repo.yaml
+# Upstream repo: org-standards/.common-repo.yaml
 - markdown:
     auto-merge: CLAUDE.md
     section: "## Organization Standards"
@@ -192,7 +192,7 @@ Consumer repos automatically get merged CLAUDE.md content:
 A base Rust configuration shares common dependencies:
 
 ```yaml
-# Source repo: rust-base/.common-repo.yaml
+# Upstream repo: rust-base/.common-repo.yaml
 - toml:
     auto-merge: Cargo.toml
     path: dependencies
@@ -202,7 +202,7 @@ Consumers inherit the base dependencies merged into their Cargo.toml.
 
 ### Consumer Override
 
-Consumers can always override source-declared behavior using the `with:` clause:
+Consumers can always override upstream-declared behavior using the `with:` clause:
 
 ```yaml
 # Consumer .common-repo.yaml
@@ -212,7 +212,7 @@ Consumers can always override source-declared behavior using the `with:` clause:
     with:
       # Override: copy instead of merge
       - include: ["CLAUDE.md"]
-      # This replaces the source-declared merge with a simple copy
+      # This replaces the upstream-declared merge with a simple copy
 ```
 
 When a consumer specifies operations for the same destination file, the consumer's operations take precedence.
@@ -240,7 +240,7 @@ All merge operators support `defer` and `auto-merge`:
 3. **Consumers can now reference it**:
    ```yaml
    - repo:
-       url: https://github.com/your-org/my-source-repo
+       url: https://github.com/your-org/my-upstream-repo
        ref: v1.0.0
    ```
 
@@ -251,7 +251,7 @@ All merge operators support `defer` and `auto-merge`:
 By default, consumers inherit from the repository root. Use the `path` option to expose a subdirectory:
 
 ```
-my-source-repo/
+my-upstream-repo/
 ├── templates/
 │   ├── rust/          # Rust project templates
 │   │   ├── .github/
@@ -267,7 +267,7 @@ Consumers select which template to use:
 ```yaml
 # Consumer's .common-repo.yaml
 - repo:
-    url: https://github.com/your-org/my-source-repo
+    url: https://github.com/your-org/my-upstream-repo
     ref: v1.0.0
     path: templates/rust  # Only inherit from this subdirectory
 ```
@@ -277,7 +277,7 @@ Consumers select which template to use:
 Group related files together to make selective inheritance easier:
 
 ```
-source-repo/
+upstream-repo/
 ├── ci/                    # CI/CD configurations
 │   ├── .github/
 │   └── .gitlab-ci.yml
@@ -295,7 +295,7 @@ Consumers can pick specific concerns:
 
 ```yaml
 - repo:
-    url: https://github.com/your-org/source-repo
+    url: https://github.com/your-org/upstream-repo
     ref: v1.0.0
     with:
       - include: ["ci/**", "quality/**"]
@@ -306,7 +306,7 @@ Consumers can pick specific concerns:
 Dotfiles (files starting with `.`) are included by default. Structure them naturally:
 
 ```
-source-repo/
+upstream-repo/
 ├── .github/
 │   ├── workflows/
 │   │   └── ci.yml
@@ -316,7 +316,7 @@ source-repo/
 └── .gitignore
 ```
 
-Files you typically **should not** include in source repos:
+Files you typically **should not** include in upstream repos:
 - `.git/` directory (automatically excluded)
 - `.env` files with secrets
 - Local IDE configurations (`.vscode/`, `.idea/`)
@@ -347,7 +347,7 @@ projectName: my-app  # CamelCase
 Document which variables consumers must provide. In your template files, use sensible defaults where possible:
 
 ```yaml
-# .github/workflows/ci.yml (in source repo)
+# .github/workflows/ci.yml (in upstream repo)
 name: CI
 
 env:
@@ -384,7 +384,7 @@ Variables can reference environment variables as defaults:
 
 ### Semantic Versioning
 
-Follow [semantic versioning](https://semver.org/) for source repositories:
+Follow [semantic versioning](https://semver.org/) for upstream repositories:
 
 - **MAJOR** (`v2.0.0`): Breaking changes that require consumer updates
 - **MINOR** (`v1.1.0`): New files or features, backward compatible
@@ -437,25 +437,25 @@ Maintain a `CHANGELOG.md` to document changes:
 - Security policy template
 ```
 
-## Testing Your Source Repository
+## Testing Your Upstream Repository
 
 ### Testing Locally
 
-Test your source repo against a local consumer before publishing:
+Test your upstream repo against a local consumer before publishing:
 
 ```bash
 # In consumer repository
 cd my-consumer-project
 
-# Reference local source repo instead of remote
+# Reference local upstream repo instead of remote
 # Edit .common-repo.yaml temporarily:
 # - repo:
-#     url: /path/to/local/source-repo
+#     url: /path/to/local/upstream-repo
 #     ref: HEAD
 
 # Or use a file:// URL
 # - repo:
-#     url: file:///absolute/path/to/source-repo
+#     url: file:///absolute/path/to/upstream-repo
 #     ref: HEAD
 
 common-repo ls      # Verify expected files
@@ -468,7 +468,7 @@ common-repo apply --dry-run
 Maintain a test consumer repository or directory:
 
 ```
-source-repo/
+upstream-repo/
 ├── .github/
 ├── templates/
 ├── tests/
@@ -478,12 +478,12 @@ source-repo/
 └── README.md
 ```
 
-The test consumer validates that your source repo works correctly:
+The test consumer validates that your upstream repo works correctly:
 
 ```yaml
 # tests/test-consumer/.common-repo.yaml
 - repo:
-    url: ../..  # Relative path to source repo root
+    url: ../..  # Relative path to upstream repo root
     ref: HEAD
     with:
       - include: ["templates/rust/**"]
@@ -491,11 +491,11 @@ The test consumer validates that your source repo works correctly:
 
 ### CI Testing Strategies
 
-Add CI workflows that validate your source repository:
+Add CI workflows that validate your upstream repository:
 
 ```yaml
 # .github/workflows/test.yml
-name: Test Source Repo
+name: Test Upstream Repo
 
 on: [push, pull_request]
 
@@ -517,12 +517,12 @@ jobs:
 
 ## Composability
 
-### Designing for Multi-Source Inheritance
+### Designing for Multiple Upstream Inheritance
 
-Consumers often inherit from multiple source repositories. Design yours to work alongside others:
+Consumers often inherit from multiple upstream repositories. Design yours to work alongside others:
 
 ```yaml
-# Consumer inheriting from multiple sources
+# Consumer inheriting from multiple upstream repos
 - repo:
     url: https://github.com/org/base-standards
     ref: v1.0.0
@@ -538,16 +538,16 @@ Consumers often inherit from multiple source repositories. Design yours to work 
 
 ### Avoiding File Conflicts
 
-When multiple sources provide similar files, conflicts can occur. Strategies to avoid this:
+When multiple upstream repos provide similar files, conflicts can occur. Strategies to avoid this:
 
 **Use specific subdirectories:**
 ```
 # Instead of:
-source-repo/
+upstream-repo/
 └── ci.yml
 
 # Use:
-source-repo/
+upstream-repo/
 └── .github/workflows/
     └── source-name-ci.yml   # Prefixed to avoid conflicts
 ```
@@ -556,17 +556,17 @@ source-repo/
 ```markdown
 ## Files Provided
 
-This source repository provides:
+This upstream repository provides:
 - `.github/workflows/lint.yml` - Linting workflow
 - `.github/workflows/test.yml` - Test workflow
 
-If you inherit from other sources, ensure they don't provide the same files,
+If you inherit from other upstream repos, ensure they don't provide the same files,
 or use `exclude` to skip conflicting files.
 ```
 
 ### Namespace Considerations
 
-Consider prefixing files with your source repo's purpose:
+Consider prefixing files with your upstream repo's purpose:
 
 ```
 org-security/
@@ -582,7 +582,7 @@ org-quality/
 
 ## What to Include and Exclude
 
-### Good Candidates for Source Repos
+### Good Candidates for Upstream Repos
 
 | File Type | Examples | Why Share |
 |-----------|----------|-----------|

--- a/docs/src/configuration.md
+++ b/docs/src/configuration.md
@@ -266,19 +266,19 @@ This operator validates but does not install tools. Warnings are issued for miss
 
 Merge operators intelligently combine configuration fragments into destination files.
 
-### Source-Declared Merge (defer/auto-merge)
+### Upstream-Declared Merge (defer/auto-merge)
 
-All merge operators support two additional options for source-declared merge behavior:
+All merge operators support two additional options for upstream-declared merge behavior:
 
 | Option | Type | Description |
 |--------|------|-------------|
 | `auto-merge` | string | Shorthand: sets source=dest to this value and implies defer=true |
-| `defer` | bool | When true, this operation only runs when repo is used as a source |
+| `defer` | bool | When true, this operation only runs when repo is used as an upstream |
 
 **`auto-merge`** is the preferred syntax when the source and destination filenames are the same:
 
 ```yaml
-# In source repo's .common-repo.yaml
+# In upstream repo's .common-repo.yaml
 - markdown:
     auto-merge: CLAUDE.md     # source=dest=CLAUDE.md, defer=true
     section: "## Rules"
@@ -295,7 +295,7 @@ All merge operators support two additional options for source-declared merge beh
     defer: true               # Only applies when repo is inherited
 ```
 
-See [Source-Declared Merge Behavior](authoring-source-repos.md#source-declared-merge-behavior) for detailed usage.
+See [Upstream-Declared Merge Behavior](authoring-upstream-repos.md#upstream-declared-merge-behavior) for detailed usage.
 
 ### Path Syntax
 
@@ -352,7 +352,7 @@ The `path` option in merge operators supports multiple notations for navigating 
 | `source` | Yes* | - | Source fragment file |
 | `dest` | Yes* | - | Destination file |
 | `auto-merge` | No | - | Shorthand: sets source=dest, implies defer=true |
-| `defer` | No | false | Only apply when repo is used as a source |
+| `defer` | No | false | Only apply when repo is used as an upstream |
 | `path` | No | root | Path to merge at (see [Path Syntax](#path-syntax)) |
 | `array_mode` | No | replace | Array handling: `replace`, `append`, or `append_unique` |
 | `append` | No | false | Deprecated: use `array_mode: append` instead |
@@ -421,7 +421,7 @@ The `path` option in merge operators supports multiple notations for navigating 
 | `source` | Yes* | - | Source fragment file |
 | `dest` | Yes* | - | Destination file |
 | `auto-merge` | No | - | Shorthand: sets source=dest, implies defer=true |
-| `defer` | No | false | Only apply when repo is used as a source |
+| `defer` | No | false | Only apply when repo is used as an upstream |
 | `path` | No | root | Dot-notation path to merge at |
 | `append` | No | false | Append to arrays instead of replace |
 | `position` | No | - | Where to append: `start` or `end` (only used when `append: true`) |
@@ -472,7 +472,7 @@ The `path` option in merge operators supports multiple notations for navigating 
 | `source` | Yes* | - | Source fragment file |
 | `dest` | Yes* | - | Destination file |
 | `auto-merge` | No | - | Shorthand: sets source=dest, implies defer=true |
-| `defer` | No | false | Only apply when repo is used as a source |
+| `defer` | No | false | Only apply when repo is used as an upstream |
 | `path` | No | root | Path to merge at (see [Path Syntax](#path-syntax)) |
 | `array_mode` | No | replace | Array handling: `replace`, `append`, or `append_unique` |
 | `append` | No | false | Deprecated: use `array_mode: append` instead |
@@ -525,7 +525,7 @@ See [Array Merge Modes](#array-merge-modes) for details on array handling option
 | `source` | Yes* | - | Source fragment file |
 | `dest` | Yes* | - | Destination file |
 | `auto-merge` | No | - | Shorthand: sets source=dest, implies defer=true |
-| `defer` | No | false | Only apply when repo is used as a source |
+| `defer` | No | false | Only apply when repo is used as an upstream |
 | `section` | No | - | INI section to merge into |
 | `append` | No | false | Append values instead of replace |
 | `allow-duplicates` | No | false | Allow duplicate keys |
@@ -575,7 +575,7 @@ See [Array Merge Modes](#array-merge-modes) for details on array handling option
 | `source` | Yes* | - | Source fragment file |
 | `dest` | Yes* | - | Destination file |
 | `auto-merge` | No | - | Shorthand: sets source=dest, implies defer=true |
-| `defer` | No | false | Only apply when repo is used as a source |
+| `defer` | No | false | Only apply when repo is used as an upstream |
 | `section` | No | - | Heading to merge under |
 | `level` | No | 2 | Heading level (1-6) |
 | `append` | No | false | Append to section |
@@ -607,9 +607,9 @@ See [Array Merge Modes](#array-merge-modes) for details on array handling option
     create-section: true
 ```
 
-**Merge CLAUDE.md rules (source-declared):**
+**Merge CLAUDE.md rules (upstream-declared):**
 ```yaml
-# In source repo - will only apply when inherited
+# In upstream repo - will only apply when inherited
 - markdown:
     auto-merge: CLAUDE.md
     section: "## Rules"

--- a/docs/src/file-filtering.md
+++ b/docs/src/file-filtering.md
@@ -1,6 +1,6 @@
 # File Filtering
 
-This guide explains how to use `include` and `exclude` patterns to control which files are inherited from source repositories.
+This guide explains how to use `include` and `exclude` patterns to control which files are inherited from upstream repositories.
 
 ## Basic Syntax
 

--- a/docs/src/introduction.md
+++ b/docs/src/introduction.md
@@ -16,7 +16,7 @@ common-repo treats repository configuration as software dependencies.
 Configuration files become:
 - **Semantically versioned** - Track exactly which version you're using
 - **Automatically updateable** - Detect outdated configs and upgrade deterministically
-- **Composable** - Pull from multiple sources and merge intelligently
+- **Composable** - Pull from multiple upstream repos and merge intelligently
 - **Inheritable** - Build upon standards that themselves extend other standards
 
 ## Quick Start

--- a/docs/src/schema.md
+++ b/docs/src/schema.md
@@ -21,9 +21,9 @@ The original v1 schema from [commonrepo](https://github.com/shakefu/commonrepo).
 # This v1 schema is from the codebase at https://github.com/shakefu/commonrepo.
 
 #########
-# Sources
+# Upstreams
 #
-# Source repositories define which of their files should be imported into the
+# Upstream repositories define which of their files should be imported into the
 # child repository.
 #
 # This should be defined in the `.commonrepo.yml` file.
@@ -89,10 +89,10 @@ install-with: [apt-get, brew, platform]
 ###########
 # Consumers
 #
-# Consumer repositories can define which sources they want to consume from, as
-# well as apply additional filters to the ones defined in the sources.
+# Consumer repositories can define which upstream repos they want to consume from, as
+# well as apply additional filters to the ones defined in the upstream repos.
 
-# define a list of source repositories, which mimic the consumer repos keys
+# define a list of upstream repositories, which mimic the consumer repos keys
 upstream:
   - url: https://github.com/shakefu/commonrepo
     ref: v1.1.0

--- a/docs/src/update-workflow.md
+++ b/docs/src/update-workflow.md
@@ -69,7 +69,7 @@ common-repo update --yes
 
 ### Selective Updates
 
-Update only specific sources using glob patterns:
+Update only specific upstream repos using glob patterns:
 
 ```bash
 # Update repos matching a pattern


### PR DESCRIPTION
## Summary

- Renames "source repo" / "source repository" terminology to "upstream repo" / "upstream repository" across all user-facing documentation
- Renames `authoring-source-repos.md` → `authoring-upstream-repos.md`
- Updates all cross-references in SUMMARY.md, README.md, configuration.md, and other docs

"Upstream" is a term devops and automation folks already know from git and package managers, making it immediately clear without explanation.

## What's NOT changed

- `source:` YAML field names in merge operators (refers to file path, not repo concept)
- CHANGELOG entries and archived context docs (historical records)
- Rust source code and CLI output (tracked separately in #232)

## Test plan

- [ ] Verify mdBook builds without broken links (`mdbook build docs/`)
- [ ] Spot-check `authoring-upstream-repos.md` for consistent terminology
- [ ] Confirm no stale `authoring-source-repos` references remain

🤖 Generated with [Claude Code](https://claude.com/claude-code)