### PR TITLE
docs: fix rename capture group syntax from %[1]s to $1

### DIFF
--- a/docs/src/configuration.md
+++ b/docs/src/configuration.md
@@ -153,15 +153,15 @@ Transform file paths using regex patterns with capture group placeholders.
 
 ```yaml
 - rename:
-    - "old-name/(.*)": "new-name/%[1]s"
-    - "^templates/(.*)": "%[1]s"
-    - "(.+)\\.template$": "%[1]s"
+    - "old-name/(.*)": "new-name/$1"
+    - "^templates/(.*)": "$1"
+    - "(.+)\\.template$": "$1"
 ```
 
 #### Placeholders
 
-- `%[1]s` - First capture group
-- `%[2]s` - Second capture group
+- `$1` - First capture group
+- `$2` - Second capture group
 - etc.
 
 #### Examples
@@ -169,21 +169,21 @@ Transform file paths using regex patterns with capture group placeholders.
 **Strip a directory prefix:**
 ```yaml
 - rename:
-    - "^files/(.*)": "%[1]s"
+    - "^files/(.*)": "$1"
 ```
 Result: `files/config.yaml` becomes `config.yaml`
 
 **Move files to a subdirectory:**
 ```yaml
 - rename:
-    - "^(.+\\.md)$": "docs/%[1]s"
+    - "^(.+\\.md)$": "docs/$1"
 ```
 Result: `README.md` becomes `docs/README.md`
 
 **Rename file extensions:**
 ```yaml
 - rename:
-    - "(.+)\\.template$": "%[1]s"
+    - "(.+)\\.template$": "$1"
 ```
 Result: `config.yaml.template` becomes `config.yaml`
 
@@ -674,7 +674,7 @@ Here's a complete configuration showing multiple operators:
 
 # Rename template files
 - rename:
-    - "(.+)\\.template$": "%[1]s"
+    - "(.+)\\.template$": "$1"
 
 # Define template variables
 - template-vars:

--- a/docs/src/file-filtering.md
+++ b/docs/src/file-filtering.md
@@ -140,7 +140,7 @@ Filtering happens before other operations in the `with` clause:
       - exclude: ["templates/internal/**"]
       # Then rename
       - rename:
-          - "^templates/(.*)": "%[1]s"
+          - "^templates/(.*)": "$1"
 ```
 
 ## Viewing Filtered Results

--- a/docs/src/recipes.md
+++ b/docs/src/recipes.md
@@ -474,7 +474,7 @@ templates/
     with:
       - include: ["templates/**"]
       - rename:
-          - "templates/(.+)\\.template$": "%[1]s"
+          - "templates/(.+)\\.template$": "$1"
 
 - template-vars:
     project_name: my-project

--- a/docs/src/schema.md
+++ b/docs/src/schema.md
@@ -59,17 +59,17 @@ template:
 # passing the working list through the rename transforms, in order
 rename:
   # Rename a path
-  - "badname/(.*)": "goodname/%[1]s"
+  - "badname/(.*)": "goodname/$1"
   # Strip one directory from the path
-  - "^files/(.*)": "%[1]s"
+  - "^files/(.*)": "$1"
   # Strip multiple directories from the path
-  - "some/parent/dir/(.*)": "%[1]s"
+  - "some/parent/dir/(.*)": "$1"
   # Recompose directories
-  - "parent/([^/]+)/dir/(.*)": "%[1]s/%[2]s"
+  - "parent/([^/]+)/dir/(.*)": "$1/$2"
   # Add a prefix to the path
-  - "(.*\\.md)": "docs/%[1]s"
+  - "(.*\\.md)": "docs/$1"
   # Move templates to repo root
-  - "templates/(.*)": "%[1]s"
+  - "templates/(.*)": "$1"
 
 # Install specs use SemVer constraints
 install:
@@ -99,7 +99,7 @@ upstream:
     overwrite: false  # TBD if this should be implemented
     include: [.*]
     exclude: [.gitignore]
-    rename: [{".*\\.md": "docs/%[1]s"}]
+    rename: [{".*\\.md": "docs/$1"}]
 
 # Template context for all upstreams...
 template-vars:


### PR DESCRIPTION
The rename implementation (`src/path.rs:regex_rename`) uses `$1`, `$2`, etc. (standard regex capture group syntax), but the docs showed `%[1]s` (Go fmt-style) which produces literal `%[1]s` in filenames.

Updated all 4 doc files:
- `docs/src/configuration.md` — main rename docs + placeholders section
- `docs/src/schema.md` — schema reference examples
- `docs/src/recipes.md` — recipe examples
- `docs/src/file-filtering.md` — filtering examples

Note: `docs/src/authoring-source-repos.md` already used the correct `$1` syntax.

Fixes #230