### PR TITLE
docs(context): fix prose lint warnings

### DIFF
--- a/context/github-action-plan.md
+++ b/context/github-action-plan.md
@@ -16,7 +16,7 @@ From `context/purpose.md`, `context/design.md`, and `README.md`:
 
 ## How It Works
 
-The action leverages existing CLI commands:
+The action uses existing CLI commands:
 
 1. **Install** - Use existing `install.sh` to get the binary
 2. **`common-repo check --updates`** - Detects if any inherited repos have newer versions
@@ -442,7 +442,7 @@ jobs:
           dry-run: 'true'
 ```
 
-### Best Practices
+### Recommendations
 
 1. **Lint in pre-commit** - Catch issues before commit with `action-validator`
 2. **Lint in CI** - Run `action-validator` in CI as backup


### PR DESCRIPTION
## Summary

- Fix 2 prose lint warnings in `context/github-action-plan.md`
  - "leverages" → "uses"
  - "Best Practices" → "Recommendations"

## Test plan

- [x] `cargo xtask check-prose .` passes with 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)