### PR TITLE
refactor(action): use setup-common-repo action

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -72,12 +72,9 @@ runs:
         fi
 
     - name: Install common-repo
-      shell: bash
-      env:
-        VERSION: ${{ inputs.version != 'latest' && inputs.version || '' }}
-      run: |
-        curl -fsSL https://raw.githubusercontent.com/common-repo/common-repo/main/install.sh | sh
-        echo "$HOME/.local/bin" >> $GITHUB_PATH
+      uses: common-repo/setup-common-repo@v1
+      with:
+        version: ${{ inputs.version }}
 
     - name: Check for updates
       id: check


### PR DESCRIPTION
## Summary

- Replace inline `curl | sh` install pattern with `common-repo/setup-common-repo@v1` in the sync action's install step

## Test plan

- [ ] Action test workflow passes
- [ ] Sync action still installs correct version

🤖 Generated with [Claude Code](https://claude.com/claude-code)