### PR TITLE
fix(processing): use operations-aware keys for consumer template-vars overrides

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -2860,4 +2860,43 @@ mod tests {
             assert_eq!(md_new, md_default);
         }
     }
+
+    #[test]
+    fn test_parse_template_vars_in_with_clause() {
+        let yaml = r#"
+- repo:
+    url: https://github.com/christmas-island/cr-semantic-release
+    ref: main
+    with:
+      - template-vars:
+          GH_APP_OWNER: my-cool-org
+"#;
+        let schema = parse(yaml).unwrap();
+        assert_eq!(schema.len(), 1);
+        match &schema[0] {
+            Operation::Repo { repo } => {
+                assert_eq!(
+                    repo.url,
+                    "https://github.com/christmas-island/cr-semantic-release"
+                );
+                assert_eq!(repo.r#ref, "main");
+                assert_eq!(
+                    repo.with.len(),
+                    1,
+                    "with: clause should have 1 operation, got: {:?}",
+                    repo.with
+                );
+                match &repo.with[0] {
+                    Operation::TemplateVars { template_vars } => {
+                        assert_eq!(
+                            template_vars.vars.get("GH_APP_OWNER"),
+                            Some(&"my-cool-org".to_string())
+                        );
+                    }
+                    other => panic!("Expected TemplateVars, got: {:?}", other),
+                }
+            }
+            _ => panic!("Expected Repo operation"),
+        }
+    }
 }

--- a/src/phases/mod.rs
+++ b/src/phases/mod.rs
@@ -71,6 +71,31 @@ impl RepoNode {
     pub fn add_child(&mut self, child: RepoNode) {
         self.children.push(child);
     }
+
+    /// Generate a unique key for this node that includes the operations fingerprint.
+    ///
+    /// The key format is `url@ref` for nodes without operations, or
+    /// `url#ops-<hash>@ref` for nodes with operations. This ensures that the
+    /// same repository referenced with different operations (e.g., different
+    /// `with:` template-vars) gets distinct keys in the intermediate filesystem
+    /// map and operation order.
+    pub fn node_key(&self) -> String {
+        if self.operations.is_empty() {
+            return format!("{}@{}", self.url, self.ref_);
+        }
+
+        // Serialize operations and hash them for a compact fingerprint
+        if let Ok(serialized) = serde_yaml::to_string(&self.operations) {
+            use std::collections::hash_map::DefaultHasher;
+            use std::hash::{Hash, Hasher};
+            let mut hasher = DefaultHasher::new();
+            serialized.hash(&mut hasher);
+            format!("{}#ops-{:016x}@{}", self.url, hasher.finish(), self.ref_)
+        } else {
+            // Fall back to simple key if serialization fails
+            format!("{}@{}", self.url, self.ref_)
+        }
+    }
 }
 
 /// Repository dependency tree for inheritance tracking

--- a/src/phases/ordering.rs
+++ b/src/phases/ordering.rs
@@ -49,7 +49,7 @@ pub fn execute(tree: &RepoTree) -> Result<OperationOrder> {
 /// The resulting order guarantees that base repositories are applied before
 /// repositories that depend on them.
 fn build_order_recursive(node: &RepoNode, order: &mut Vec<String>, visited: &mut HashSet<String>) {
-    let node_key = format!("{}@{}", node.url, node.ref_);
+    let node_key = node.node_key();
 
     // Skip if already processed (shouldn't happen in a tree, but safety check)
     if visited.contains(&node_key) {

--- a/src/phases/processing.rs
+++ b/src/phases/processing.rs
@@ -82,7 +82,7 @@ fn process_repo_recursive(
     }
 
     // Process this repository
-    let key = format!("{}@{}", node.url, node.ref_);
+    let key = node.node_key();
     if let std::collections::hash_map::Entry::Vacant(e) = intermediate_fss.entry(key) {
         let intermediate_fs = process_single_repo(node, repo_manager, cache)?;
         e.insert(intermediate_fs);
@@ -272,7 +272,7 @@ fn apply_operation(fs: &mut MemoryFS, operation: &Operation) -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::config::{ExcludeOp, Operation, RepoOp};
+    use crate::config::{ExcludeOp, Operation, RepoOp, TemplateVars};
     use crate::filesystem::MemoryFS;
     use crate::repository::{CacheOperations, GitOperations, RepositoryManager};
     use std::collections::HashMap;
@@ -469,6 +469,7 @@ mod tests {
             "main".to_string(),
             operations.clone(),
         );
+        let repo_key = child1.node_key();
         let child2 = RepoNode::new(
             "https://example.com/repo.git".to_string(),
             "main".to_string(),
@@ -489,10 +490,76 @@ mod tests {
         assert_eq!(intermediate.len(), 2);
 
         // Ensure the cached filesystem respected the exclude operation
-        let repo_key = "https://example.com/repo.git@main";
-        let repo_fs = &intermediate.get(repo_key).unwrap().fs;
+        let repo_fs = &intermediate.get(&repo_key).unwrap().fs;
         assert!(repo_fs.exists("keep.txt"));
         assert!(!repo_fs.exists("temp.tmp"));
+    }
+
+    #[test]
+    fn test_same_repo_different_operations_get_separate_entries() {
+        // When the same repo URL+ref appears in the tree with different operations
+        // (e.g., different template-vars from different consumers), each instance
+        // should get its own entry in intermediate_fss with its own template vars.
+        let clone_calls = Arc::new(Mutex::new(0));
+        let cached_flag = Arc::new(Mutex::new(false));
+
+        let repo_manager = RepositoryManager::with_operations(
+            Box::new(MockGitOps::new(clone_calls.clone(), cached_flag.clone())),
+            Box::new(MockCacheOps::new(cached_flag.clone())),
+        );
+
+        let cache = RepoCache::new();
+
+        // Two references to the same repo but with different template-vars
+        let child1_ops = vec![Operation::TemplateVars {
+            template_vars: TemplateVars {
+                vars: {
+                    let mut vars = HashMap::new();
+                    vars.insert("OWNER".to_string(), "org-a".to_string());
+                    vars
+                },
+            },
+        }];
+
+        let child2_ops = vec![Operation::TemplateVars {
+            template_vars: TemplateVars {
+                vars: {
+                    let mut vars = HashMap::new();
+                    vars.insert("OWNER".to_string(), "org-b".to_string());
+                    vars
+                },
+            },
+        }];
+
+        let child1 = RepoNode::new(
+            "https://example.com/repo.git".to_string(),
+            "main".to_string(),
+            child1_ops,
+        );
+        let child1_key = child1.node_key();
+
+        let child2 = RepoNode::new(
+            "https://example.com/repo.git".to_string(),
+            "main".to_string(),
+            child2_ops,
+        );
+        let child2_key = child2.node_key();
+
+        // Keys should be different because operations differ
+        assert_ne!(child1_key, child2_key);
+
+        let tree = build_tree_with_children(vec![child1, child2]);
+        let intermediate = execute(&tree, &repo_manager, &cache).expect("phase2 execute");
+
+        // Should have 3 entries: local + two separate repo entries
+        assert_eq!(intermediate.len(), 3);
+
+        // Each entry should have its own template vars
+        let fs1 = intermediate.get(&child1_key).unwrap();
+        assert_eq!(fs1.template_vars.get("OWNER"), Some(&"org-a".to_string()));
+
+        let fs2 = intermediate.get(&child2_key).unwrap();
+        assert_eq!(fs2.template_vars.get("OWNER"), Some(&"org-b".to_string()));
     }
 
     #[test]
@@ -1208,6 +1275,44 @@ mod tests {
             assert_eq!(result.len(), 1);
             assert_eq!(result.get("KEY"), Some(&"value".to_string()));
         }
+
+        #[test]
+        fn test_collect_template_vars_consumer_overrides_source() {
+            // Simulates combined operations after discovery:
+            // source template-vars come first, consumer with: template-vars come last
+            let mut source_vars = HashMap::new();
+            source_vars.insert("GH_APP_OWNER".to_string(), "christmas-island".to_string());
+            source_vars.insert(
+                "GH_APP_ID_VAR".to_string(),
+                "CHRISTMAS_ISLAND_APP_ID".to_string(),
+            );
+
+            let mut consumer_vars = HashMap::new();
+            consumer_vars.insert("GH_APP_OWNER".to_string(), "my-cool-org".to_string());
+
+            let operations = vec![
+                // Source operations come first (from extract_source_operations)
+                Operation::TemplateVars {
+                    template_vars: TemplateVars { vars: source_vars },
+                },
+                // Consumer with: operations come last
+                Operation::TemplateVars {
+                    template_vars: TemplateVars {
+                        vars: consumer_vars,
+                    },
+                },
+            ];
+
+            let result = collect_template_vars(&operations).expect("should not error");
+            assert_eq!(result.len(), 2);
+            // Consumer override should win
+            assert_eq!(result.get("GH_APP_OWNER"), Some(&"my-cool-org".to_string()));
+            // Non-overridden source var should be preserved
+            assert_eq!(
+                result.get("GH_APP_ID_VAR"),
+                Some(&"CHRISTMAS_ISLAND_APP_ID".to_string())
+            );
+        }
     }
 
     mod merge_operations_tests {
@@ -1854,15 +1959,14 @@ mod tests {
                     },
                 }],
             );
+            let child_key = child.node_key();
             root.add_child(child);
             let tree = RepoTree::new(root);
 
             let result = execute(&tree, &repo_manager, &cache);
             assert!(result.is_ok());
             let intermediate_fss = result.unwrap();
-            let child_fs = intermediate_fss
-                .get("https://github.com/example/repo.git@main")
-                .unwrap();
+            let child_fs = intermediate_fss.get(&child_key).unwrap();
             // The exclude operation should have removed .txt files
             assert!(!child_fs.fs.exists("file.txt"));
         }

--- a/tests/cli_e2e_source_ops.rs
+++ b/tests/cli_e2e_source_ops.rs
@@ -909,3 +909,169 @@ fn test_ls_respects_consumer_with_clause_excludes() {
         "ls should not show with-clause-excluded LICENSE, got:\n{output}"
     );
 }
+
+// =============================================================================
+// Bug #249: Source-declared template vars baked into cache — consumer overrides ignored
+// =============================================================================
+
+/// Test that consumer's `with:` template-vars override source's default template-vars.
+///
+/// When a source repo declares `template:` and `template-vars:`, and a consumer
+/// overrides some vars via `with: template-vars:`, the consumer's values should
+/// take precedence over the source's defaults.
+#[test]
+#[cfg_attr(not(feature = "integration-tests"), ignore)]
+fn test_consumer_with_template_vars_override_source_defaults() {
+    // Create source repository with template + template-vars
+    let source_repo = assert_fs::TempDir::new().unwrap();
+    init_git_repo(
+        &source_repo,
+        &[
+            (
+                ".common-repo.yaml",
+                r#"- include:
+    - "src/**"
+    - "src/.*"
+    - "src/.*/**"
+- template:
+    - "src/.github/workflows/release.yaml"
+- template-vars:
+    GH_APP_OWNER: christmas-island
+    GH_APP_ID_VAR: CHRISTMAS_ISLAND_APP_ID
+- rename:
+    - from: "^src/(.*)"
+      to: "$1"
+"#,
+            ),
+            (
+                "src/.github/workflows/release.yaml",
+                "owner: ${GH_APP_OWNER:-christmas-island}\napp_id: ${GH_APP_ID_VAR}\n",
+            ),
+        ],
+    )
+    .unwrap();
+
+    // Create consumer that overrides GH_APP_OWNER via with: clause
+    let consumer = assert_fs::TempDir::new().unwrap();
+    let source_url = format!("file://{}", source_repo.path().display());
+
+    consumer
+        .child(".common-repo.yaml")
+        .write_str(&format!(
+            r#"- repo:
+    url: "{}"
+    ref: main
+    with:
+      - template-vars:
+          GH_APP_OWNER: my-cool-org
+"#,
+            source_url
+        ))
+        .unwrap();
+
+    let mut cmd = cargo_bin_cmd!("common-repo");
+
+    cmd.current_dir(consumer.path())
+        .arg("apply")
+        .arg("--verbose")
+        .assert()
+        .success();
+
+    // Verify the template was expanded with consumer's override
+    let workflow_path = consumer.child(".github/workflows/release.yaml");
+    workflow_path.assert(predicate::path::exists());
+
+    let content = std::fs::read_to_string(workflow_path.path()).unwrap();
+
+    // Consumer override should win for GH_APP_OWNER
+    assert!(
+        content.contains("owner: my-cool-org"),
+        "Consumer's template-vars override should be applied.\n\
+         Expected 'owner: my-cool-org' but got:\n{}",
+        content
+    );
+
+    // Source defaults should be preserved for non-overridden vars
+    assert!(
+        content.contains("app_id: CHRISTMAS_ISLAND_APP_ID"),
+        "Source's non-overridden template-vars should be preserved.\n\
+         Expected 'app_id: CHRISTMAS_ISLAND_APP_ID' but got:\n{}",
+        content
+    );
+}
+
+/// Test that consumer's top-level template-vars override source's defaults.
+///
+/// When a consumer has top-level `template-vars:` (not in `with:`), these should
+/// override the source's default values during Phase 4 composite construction.
+#[test]
+#[cfg_attr(not(feature = "integration-tests"), ignore)]
+fn test_consumer_top_level_template_vars_override_source_defaults() {
+    // Create source repository with template + template-vars
+    let source_repo = assert_fs::TempDir::new().unwrap();
+    init_git_repo(
+        &source_repo,
+        &[
+            (
+                ".common-repo.yaml",
+                r#"- include:
+    - "configs/**"
+- template:
+    - "configs/app.yaml"
+- template-vars:
+    APP_NAME: default-app
+    APP_PORT: "8080"
+"#,
+            ),
+            ("configs/app.yaml", "name: ${APP_NAME}\nport: ${APP_PORT}\n"),
+        ],
+    )
+    .unwrap();
+
+    // Create consumer with top-level template-vars override
+    let consumer = assert_fs::TempDir::new().unwrap();
+    let source_url = format!("file://{}", source_repo.path().display());
+
+    consumer
+        .child(".common-repo.yaml")
+        .write_str(&format!(
+            r#"- template-vars:
+    APP_NAME: my-custom-app
+- repo:
+    url: "{}"
+    ref: main
+"#,
+            source_url
+        ))
+        .unwrap();
+
+    let mut cmd = cargo_bin_cmd!("common-repo");
+
+    cmd.current_dir(consumer.path())
+        .arg("apply")
+        .arg("--verbose")
+        .assert()
+        .success();
+
+    // Verify the template was expanded with consumer's override
+    let config_path = consumer.child("configs/app.yaml");
+    config_path.assert(predicate::path::exists());
+
+    let content = std::fs::read_to_string(config_path.path()).unwrap();
+
+    // Consumer override should win for APP_NAME
+    assert!(
+        content.contains("name: my-custom-app"),
+        "Consumer's top-level template-vars override should be applied.\n\
+         Expected 'name: my-custom-app' but got:\n{}",
+        content
+    );
+
+    // Source defaults should be preserved for non-overridden vars
+    assert!(
+        content.contains("port: 8080"),
+        "Source's non-overridden template-vars should be preserved.\n\
+         Expected 'port: 8080' but got:\n{}",
+        content
+    );
+}


### PR DESCRIPTION
## Summary

- Phase 2 and Phase 3 used bare `url@ref` as the key for intermediate filesystems and operation ordering, causing the same source repo referenced with different `with:` template-vars to silently drop all but the first instance's overrides
- Add `RepoNode::node_key()` that includes an operations fingerprint hash, ensuring each distinct set of operations gets its own entry in both intermediate filesystems and the operation order
- Add E2E integration tests covering consumer template-vars overrides via both `with:` clause and top-level declaration, plus unit tests for override ordering and diamond-dependency separation

## Test plan

- [x] All 902 unit tests pass (`cargo nextest run`)
- [x] E2E tests pass with `--features integration-tests` for both `with:` and top-level template-vars overrides
- [x] CI checks pass (`./script/ci`)
- [ ] Manual test with the reproduction case from #249 against a real source repo

Closes #249

🤖 Generated with [Claude Code](https://claude.com/claude-code)