### PR TITLE
fix: resolve XML merge parity gaps and stale spec annotations

### DIFF
--- a/spec/common-repo.allium
+++ b/spec/common-repo.allium
@@ -487,6 +487,15 @@ rule CombineUpstreamOperations {
         -- This ordering means upstreams control what they expose (filtering),
         -- upstreams declare how their files merge (deferred merges), and
         -- consumers can further filter or transform the result (with: clause).
+        --
+        -- The with: clause only supports filtering and transformation operations:
+        --   include, exclude, rename, template, tools
+        -- The following operations are prohibited in with: clauses:
+        --   repo    — would create circular dependencies
+        --   self    — meaningless in upstream context
+        --   template_vars — must be collected globally across all repos
+        --   yaml, json, toml, ini, markdown, xml — merges execute during
+        --     composition (Phase 4), not during repo loading
 }
 
 rule DetectCycles {

--- a/spec/detailed/merge-operations.allium
+++ b/spec/detailed/merge-operations.allium
@@ -64,8 +64,7 @@ rule AutoCreateDestination {
 -- --------------------------------------------------------------------------
 
 rule MissingSourceExplicit {
-    -- @status: Implemented (partial)
-    -- Sequential-context hints planned in Phase B Task 14
+    -- @status: Implemented
     when: ApplyMerge(op, filesystem)
     requires: op.source != null
     requires: op.auto_merge = null
@@ -83,8 +82,7 @@ rule MissingSourceExplicit {
 }
 
 rule MissingSourceAutoMerge {
-    -- @status: Implemented (partial)
-    -- Sequential-context hints planned in Phase B Task 14
+    -- @status: Implemented
     when: ApplyMerge(op, filesystem)
     requires: op.auto_merge != null
     requires: not filesystem.contains(op.effective_source)

--- a/src/config.rs
+++ b/src/config.rs
@@ -1075,7 +1075,7 @@ impl Operation {
         }
     }
 
-    /// Returns true if this is a merge operation (yaml, json, toml, ini, markdown).
+    /// Returns true if this is a merge operation (yaml, json, toml, ini, markdown, xml).
     pub fn is_merge_operation(&self) -> bool {
         matches!(
             self,
@@ -1084,6 +1084,7 @@ impl Operation {
                 | Operation::Toml { .. }
                 | Operation::Ini { .. }
                 | Operation::Markdown { .. }
+                | Operation::Xml { .. }
         )
     }
 }
@@ -3397,6 +3398,38 @@ mod tests {
             let warnings = check_merge_provenance(&consumer_config, &upstream_deferred_ops);
 
             assert_eq!(warnings.len(), 0);
+        }
+
+        #[test]
+        fn test_xml_merge_is_recognized_as_merge_operation() {
+            let xml_op = Operation::Xml {
+                xml: XmlMergeOp {
+                    source: Some("fragment.xml".to_string()),
+                    dest: Some("config.xml".to_string()),
+                    ..Default::default()
+                },
+            };
+            assert!(xml_op.is_merge_operation());
+        }
+
+        #[test]
+        fn test_xml_merge_triggers_provenance_warning() {
+            // An XML consumer merge whose source is not in upstream deferred ops
+            // should produce a provenance warning
+            let consumer_config = vec![Operation::Xml {
+                xml: XmlMergeOp {
+                    source: Some("unknown-fragment.xml".to_string()),
+                    dest: Some("config.xml".to_string()),
+                    ..Default::default()
+                },
+            }];
+            let upstream_deferred_ops: Vec<Operation> = vec![];
+
+            let warnings = check_merge_provenance(&consumer_config, &upstream_deferred_ops);
+
+            assert_eq!(warnings.len(), 1);
+            assert_eq!(warnings[0].operation_index, 0);
+            assert_eq!(warnings[0].source_path, "unknown-fragment.xml");
         }
     }
 }

--- a/src/phases/composite.rs
+++ b/src/phases/composite.rs
@@ -255,7 +255,13 @@ fn make_explicit_merge_op(op: &Operation, source: &str, dest: &str) -> Operation
                 source: Some(source.to_string()),
                 dest: Some(dest.to_string()),
                 path: xml.path.clone(),
-                array_mode: xml.array_mode,
+                // Inter-repo accumulation: upgrade default Replace to AppendUnique
+                // so each upstream's array entries are preserved, not overwritten.
+                array_mode: if xml.array_mode == crate::config::ArrayMergeMode::Replace {
+                    crate::config::ArrayMergeMode::AppendUnique
+                } else {
+                    xml.array_mode
+                },
                 position: xml.position,
                 defer: None,
                 auto_merge: None,
@@ -1429,6 +1435,81 @@ port = 8080
                 String::from_utf8(composite.get_file("config.yaml").unwrap().content.clone())
                     .unwrap();
             assert!(content.contains("first"));
+        }
+
+        #[test]
+        fn test_xml_auto_merge_upgrades_array_mode_from_replace() {
+            use crate::config::{ArrayMergeMode, Operation, XmlMergeOp};
+
+            // Two repos both provide config.xml with default (Replace) array_mode
+            // and repeated <plugin> elements (array-like).
+            // The auto-merge upgrade should change Replace -> AppendUnique so both
+            // repos' array entries are preserved, not overwritten.
+            let xml_a = "\
+<?xml version=\"1.0\"?>\
+<config>\
+<plugin>lint</plugin>\
+<plugin>fmt</plugin>\
+</config>";
+            let xml_b = "\
+<?xml version=\"1.0\"?>\
+<config>\
+<plugin>test</plugin>\
+<plugin>fmt</plugin>\
+</config>";
+
+            let mut fs_a = MemoryFS::new();
+            fs_a.add_file_string("config.xml", xml_a).unwrap();
+            let mut ifs_a = IntermediateFS::new(
+                fs_a,
+                "https://github.com/repo-a.git".to_string(),
+                "main".to_string(),
+            );
+            ifs_a.merge_operations.push(Operation::Xml {
+                xml: XmlMergeOp::new()
+                    .auto_merge("config.xml")
+                    .array_mode(ArrayMergeMode::Replace),
+            });
+
+            let mut fs_b = MemoryFS::new();
+            fs_b.add_file_string("config.xml", xml_b).unwrap();
+            let mut ifs_b = IntermediateFS::new(
+                fs_b,
+                "https://github.com/repo-b.git".to_string(),
+                "main".to_string(),
+            );
+            ifs_b.merge_operations.push(Operation::Xml {
+                xml: XmlMergeOp::new()
+                    .auto_merge("config.xml")
+                    .array_mode(ArrayMergeMode::Replace),
+            });
+
+            let mut intermediate_fss = HashMap::new();
+            let key_a = "https://github.com/repo-a.git@main".to_string();
+            let key_b = "https://github.com/repo-b.git@main".to_string();
+            intermediate_fss.insert(key_a.clone(), ifs_a);
+            intermediate_fss.insert(key_b.clone(), ifs_b);
+
+            let order = OperationOrder::new(vec![key_a, key_b]);
+            let (composite, _) = execute(&order, &intermediate_fss).unwrap();
+
+            let content =
+                String::from_utf8(composite.get_file("config.xml").unwrap().content.clone())
+                    .unwrap();
+            // With AppendUnique upgrade, all unique plugins from both repos should
+            // be present. "fmt" appears in both but should only appear once.
+            assert!(
+                content.contains("<plugin>lint</plugin>"),
+                "repo-a 'lint' preserved"
+            );
+            assert!(
+                content.contains("<plugin>test</plugin>"),
+                "repo-b 'test' preserved"
+            );
+            assert!(
+                content.contains("<plugin>fmt</plugin>"),
+                "shared 'fmt' preserved"
+            );
         }
     }
 


### PR DESCRIPTION
## Summary

- **XML missing from `is_merge_operation()`** — XML merge operations were excluded from the match, so `check_merge_provenance()` never warned about XML consumer merges referencing files not provided by any upstream
- **XML auto-merge skipped `array_mode` upgrade** — `make_explicit_merge_op` passed XML `array_mode` through unchanged during inter-repo auto-merge conflict resolution, while YAML/JSON/TOML all upgrade `Replace` → `AppendUnique` to preserve array contributions from multiple upstreams
- **Stale `@status` annotations** — `MissingSourceExplicit` and `MissingSourceAutoMerge` rules were marked `Implemented (partial)` but sequential-context hints are fully implemented in all six merge modules
- **Missing `with:` clause restrictions** — The spec did not document which operations are prohibited in `with:` clauses (repo, self, template_vars, all merges)

Found via `allium:weed` spec-code divergence analysis.

## Test plan

- [x] `test_xml_merge_is_recognized_as_merge_operation` — verifies `Operation::Xml` returns `true` from `is_merge_operation()`
- [x] `test_xml_merge_triggers_provenance_warning` — verifies XML consumer merge without upstream match produces a warning
- [x] `test_xml_auto_merge_upgrades_array_mode_from_replace` — verifies two repos with repeated XML elements and default Replace mode both contribute entries after AppendUnique upgrade
- [x] Full test suite: 1060 tests pass, 0 failures
- [x] CI checks pass (fmt, clippy, prose)