### PR TITLE
fix: unify source and self: pipelines to same sequential code path

### DIFF
--- a/spec/common-repo.allium
+++ b/spec/common-repo.allium
@@ -393,10 +393,17 @@ rule SelfOperatorPartition {
     -- @status: Implemented
     when: ExecutePull(config)
 
-    -- Before the main pipeline runs, partition the config into two sets:
+    -- Before pipeline execution, partition the config into two sets:
     --   1. self_config: operations nested inside self: blocks
     --   2. source_config: all other operations (the source API)
-    -- These run as independent pipelines with no shared state.
+    -- Both sets execute through the same sequential pipeline code path
+    -- (execute_sequential_pipeline). They run as independent invocations
+    -- with no shared in-memory state. The only behavioural difference is
+    -- inheritance visibility:
+    --   - source operations are exposed to consumers when this repo is
+    --     used as an upstream (filtering ops, deferred merges, repo children)
+    --   - self operations are invisible to consumers and apply only to
+    --     the defining repo's working directory
     let self_ops = config.self_operations
     let source_ops = config.source_operations
 
@@ -409,15 +416,17 @@ rule ExecuteSelfPipeline {
     when: SelfPipelineReady(self_ops)
     requires: self_ops.count > 0
 
-    -- Each self: block's inner operations run through the full 6-phase
-    -- pipeline independently. Output is written to the working directory.
+    -- Each self: block's inner operations run through
+    -- execute_sequential_pipeline — the same code path used by source
+    -- blocks. Output is written to the working directory.
     for self_op in self_ops:
         ensures: SelfPipelineExecuted(self_op)
 
     @guidance
-        -- The self pipeline reuses the same phase logic (discovery, processing,
-        -- ordering, composition, local merge, write). It is not a new pipeline
-        -- implementation — it is a second invocation with different input.
+        -- Both self: and source blocks call the same sequential pipeline
+        -- entry point. There is no separate pipeline implementation for
+        -- either block type. The difference is purely in what is exposed
+        -- to consumers (see SelfOperatorPartition).
         --
         -- Self pipelines follow the same CompositePrecedence invariant:
         -- composite (upstream-derived) whole files overwrite local files.
@@ -518,6 +527,12 @@ rule ProcessRepository {
     when: UpstreamConfigDiscovered(node)
     requires: node.url != "local"
 
+    -- Prepare the upstream's IntermediateFS. In the sequential model this
+    -- happens lazily when a repo: operation fires at its declaration
+    -- position (see ApplyRepoInline in detailed/operators.allium). The
+    -- IntermediateFS captures the upstream's cloned content, collected
+    -- template variables, and deferred merge operations — all of which
+    -- feed into the sub-pipeline that resolves at the repo: position.
     ensures: IntermediateFS.created(
         url: node.url,
         ref: node.ref,
@@ -598,7 +613,10 @@ rule DetermineOperationOrder {
     -- @status: Implemented
     when: AllRepositoriesProcessed(tree)
 
-    -- Depth-first post-order: children before parents
+    -- Cross-repo ordering: depth-first post-order (children before parents).
+    -- This governs the order in which repo: operations resolve their
+    -- sub-pipelines. Within each block (self:, source, with:), operation
+    -- order is YAML declaration order (see SequentialOperationExecution).
     ensures: OperationOrder.created(
         order: post_order_keys(tree.root)
     )
@@ -608,6 +626,12 @@ rule DetermineOperationOrder {
         -- Each repository appears exactly once in the order.
         -- The node key includes an operations fingerprint when the same
         -- repo+ref is referenced with different operations.
+        --
+        -- In the sequential model, this ordering is used when a repo:
+        -- operation fires: its sub-pipeline resolves child repo: operations
+        -- recursively in depth-first post-order. The ordering does not
+        -- create a separate batch phase; it describes the recursive
+        -- resolution order within the sequential pass.
 }
 
 -- ==========================================================================
@@ -674,15 +698,16 @@ rule BuildComposite {
     ensures: CompositeBuilt(order, intermediate_fss)
 
     @guidance
-        -- The sequential pass replaces the previous model where all
-        -- repo: operations were discovered and resolved up-front
+        -- The sequential pass replaces the previous batch model where
+        -- all repo: operations were discovered and resolved up-front
         -- (Phase 1) and composite construction was a simple fold
         -- over IntermediateFSs.
         --
-        -- In the new model, the composite grows incrementally as
-        -- each operation fires. Include pulls from source FS. Repo:
-        -- resolves and integrates. Exclude removes. The composite
-        -- at any point reflects all operations that have fired so far.
+        -- In the sequential model, the composite grows incrementally
+        -- as each operation fires. Include pulls from source FS.
+        -- Repo: resolves and integrates. Exclude removes. The
+        -- composite at any point reflects all operations that have
+        -- fired so far.
         --
         -- See detailed/auto-merge-composition.allium for auto-merge
         -- behaviour when sub-repo content conflicts with existing
@@ -861,9 +886,11 @@ invariant NoCyclesInRepoTree {
 
 invariant SelfIsolation {
     -- @status: Implemented
-    -- Self pipelines never share in-memory filesystem state with the
-    -- source pipeline. Each self: block executes an independent pipeline
-    -- invocation with its own MemoryFS.
+    -- Self and source blocks use the same sequential pipeline code path
+    -- (execute_sequential_pipeline) but never share in-memory filesystem
+    -- state. Each self: block executes an independent pipeline invocation
+    -- with its own MemoryFS. The code path is identical; the state is
+    -- isolated.
     --
     -- Note: self and source pipelines share the on-disk working directory.
     -- The source pipeline's write output is visible to the self pipeline's

--- a/src/phases/composite.rs
+++ b/src/phases/composite.rs
@@ -47,11 +47,15 @@ use crate::config::Operation;
 use crate::error::{Error, Result};
 use crate::filesystem::MemoryFS;
 
-/// Executes Phase 4 of the pipeline.
+/// Executes Phase 4 of the pipeline (batch mode).
 ///
 /// This function orchestrates the construction of the composite filesystem
 /// by first processing all templates with a unified set of variables and
 /// then merging the resulting filesystems in the correct order.
+///
+/// Used by unit tests; the production pipeline now uses the sequential
+/// model via [`super::orchestrator::execute_sequential_pipeline`].
+#[allow(dead_code)]
 pub fn execute(
     order: &OperationOrder,
     intermediate_fss: &HashMap<String, IntermediateFS>,
@@ -136,6 +140,7 @@ fn merge_filesystem(target_fs: &mut MemoryFS, source_fs: &MemoryFS) -> Result<()
 ///
 /// Only collects non-explicitly-deferred ops. Used by the batch pipeline
 /// (Phase 4) where `defer: true` ops are reserved for Phase 5.
+#[allow(dead_code)]
 fn collect_auto_merge_targets(ops: &[Operation]) -> HashMap<String, Operation> {
     let mut targets = HashMap::new();
     for op in ops {
@@ -179,7 +184,7 @@ fn is_explicitly_deferred(op: &Operation) -> bool {
 }
 
 /// Extract the auto-merge target path from an operation, if it has one.
-fn get_auto_merge_path(op: &Operation) -> Option<&str> {
+pub(crate) fn get_auto_merge_path(op: &Operation) -> Option<&str> {
     match op {
         Operation::Yaml { yaml } => yaml.auto_merge.as_deref(),
         Operation::Json { json } => json.auto_merge.as_deref(),
@@ -193,7 +198,7 @@ fn get_auto_merge_path(op: &Operation) -> Option<&str> {
 
 /// Create a synthetic merge operation with explicit source and dest paths,
 /// preserving all other parameters from the original auto-merge operation.
-fn make_explicit_merge_op(op: &Operation, source: &str, dest: &str) -> Operation {
+pub(crate) fn make_explicit_merge_op(op: &Operation, source: &str, dest: &str) -> Operation {
     match op {
         Operation::Yaml { yaml } => Operation::Yaml {
             yaml: crate::config::YamlMergeOp {
@@ -287,6 +292,22 @@ fn make_explicit_merge_op(op: &Operation, source: &str, dest: &str) -> Operation
         // Should not be called with non-merge operations
         _ => op.clone(),
     }
+}
+
+/// Overlay composite files onto a target FS, using format-aware auto-merge
+/// for paths that have auto-merge declarations.
+///
+/// This is the public entry point used by the orchestrator to merge the
+/// composite (built during the sequential pass) onto local files during
+/// Phase 5. For paths where both target and source have a file and an
+/// auto-merge declaration exists, the content is merged rather than
+/// overwritten.
+pub(crate) fn merge_composite_with_auto_merge(
+    target_fs: &mut MemoryFS,
+    source_fs: &MemoryFS,
+    auto_merge_targets: &HashMap<String, Operation>,
+) -> Result<()> {
+    merge_filesystem_with_auto_merge(target_fs, source_fs, auto_merge_targets)
 }
 
 /// Merge a source filesystem into a target filesystem with auto-merge awareness.

--- a/src/phases/local_merge.rs
+++ b/src/phases/local_merge.rs
@@ -43,11 +43,15 @@ use crate::defaults::{ALT_CONFIG_FILENAME, DEFAULT_CONFIG_FILENAME};
 use crate::error::{Error, Result};
 use crate::filesystem::{File, MemoryFS};
 
-/// Executes Phase 5 of the pipeline.
+/// Executes Phase 5 of the pipeline (batch mode).
 ///
 /// Combines local files with the composite filesystem (composite wins for
 /// shared paths), executes deferred merge operations, then runs all consumer
 /// operations in YAML declaration order.
+///
+/// Used by unit tests; the production pipeline now uses the sequential
+/// model which handles local file loading and combination inline.
+#[allow(dead_code)]
 pub fn execute(
     composite_fs: &MemoryFS,
     local_config: &Schema,
@@ -199,6 +203,7 @@ pub(crate) fn load_local_fs(working_dir: &Path) -> Result<MemoryFS> {
 }
 
 /// Merge composite files over local files (composite wins for shared paths)
+#[allow(dead_code)]
 fn merge_composite_over_local(final_fs: &mut MemoryFS, composite_fs: &MemoryFS) -> Result<()> {
     for (path, file) in composite_fs.files() {
         final_fs.add_file(path, file.clone())?;
@@ -212,6 +217,7 @@ fn merge_composite_over_local(final_fs: &mut MemoryFS, composite_fs: &MemoryFS) 
 /// then processes templates with collected variables. Merge and filter operations
 /// are skipped here; they run later in `apply_consumer_operations` against the
 /// combined filesystem.
+#[allow(dead_code)]
 fn apply_local_operations_to_local_fs(
     local_fs: &mut MemoryFS,
     local_config: &Schema,
@@ -247,6 +253,7 @@ fn apply_local_operations_to_local_fs(
 /// All operations -- merges (yaml, json, toml, ini, markdown, xml) and filters
 /// (include, exclude, rename) -- execute sequentially in the order they appear
 /// in the config. YAML order = execution order.
+#[allow(dead_code)]
 fn apply_consumer_operations(final_fs: &mut MemoryFS, local_config: &Schema) -> Result<()> {
     use crate::operators;
 

--- a/src/phases/mod.rs
+++ b/src/phases/mod.rs
@@ -75,6 +75,7 @@ pub mod orchestrator;
 pub(crate) use composite as phase4;
 pub(crate) use discovery as phase1;
 pub(crate) use local_merge as phase5;
+#[allow(unused_imports)]
 pub(crate) use ordering as phase3;
 pub(crate) use processing as phase2;
 pub(crate) use write as phase6;

--- a/src/phases/orchestrator.rs
+++ b/src/phases/orchestrator.rs
@@ -1,27 +1,31 @@
 //! Orchestrator for the complete pull operation.
 //!
 //! Coordinates all phases to provide a clean API for the complete pull
-//! operation. Two pipeline modes are supported:
+//! operation. Both source and `self:` blocks use the same sequential
+//! pipeline (`execute_sequential_pipeline`). Operations run in YAML
+//! declaration order. Each nested `repo:` is resolved lazily via
+//! `resolve_repo_inline`, and the sub-composite merges immediately
+//! through `phase4::integrate_sub_composite` instead of a single batch
+//! Phase 4 pass over all intermediates.
 //!
-//! - **Batch pipeline** (`execute_source_pipeline`): for top-level source
-//!   operations (everything outside `self:`). Phases 1-6 run in batch; Phase 4
-//!   calls `phase4::execute` once over the full intermediate map from Phase 2.
-//! - **Sequential pipeline** (`execute_sequential_pipeline`): for `self:`
-//!   blocks. Operations run in YAML declaration order. Each nested `repo:` is
-//!   resolved lazily via `resolve_repo_inline`, and the sub-composite merges
-//!   immediately through `phase4::integrate_sub_composite` instead of a single
-//!   batch Phase 4 pass over all intermediates.
+//! The two block types differ only in starting state and finalization:
+//!
+//! - **`self:` blocks** start from the local working directory and write
+//!   directly after the sequential pass.
+//! - **Source blocks** start from an empty FS and run Phase 5 (local file
+//!   merge) after the sequential pass to combine the composite with local
+//!   files.
 //!
 //! [`execute_pull`] partitions the config into source and `self:` operations,
-//! runs the batch pipeline for sources, then runs the sequential pipeline
-//! for each `self:` block.
+//! runs the sequential pipeline for sources, then runs the sequential
+//! pipeline for each `self:` block.
 
 use std::collections::{HashMap, HashSet};
 use std::path::Path;
 
 use log::warn;
 
-use super::{phase1, phase2, phase3, phase4, phase5, phase6, ClonedRepo, IntermediateFS};
+use super::{phase1, phase2, phase4, phase5, phase6, ClonedRepo, IntermediateFS};
 use crate::cache::RepoCache;
 use crate::config::{Operation, Schema, SelfOp};
 use crate::error::Result;
@@ -112,6 +116,10 @@ fn resolve_repo_inline_inner(
     let mut merge_operations = phase2::collect_merge_operations(&cloned.operations);
 
     let mut fs = cloned.fs.clone();
+    // Track auto-merge targets across nested repos so cross-upstream
+    // auto-merges accumulate correctly (e.g., when a chained upstream
+    // also declares auto-merge for the same file).
+    let mut accumulated_auto_merge_targets = HashMap::new();
 
     for operation in &cloned.operations {
         match operation {
@@ -149,9 +157,24 @@ fn resolve_repo_inline_inner(
                     let nested_result =
                         resolve_repo_inline_inner(nested_cloned, cloned_repos, cache, visited)?;
 
-                    fs.merge(&nested_result.fs);
+                    // Use auto-merge-aware integration so that chained
+                    // repos with auto-merge declarations accumulate
+                    // content instead of overwriting via last-write-wins.
+                    let nested_intermediate = IntermediateFS::new_with_vars_and_merges(
+                        nested_result.fs.clone(),
+                        nested_result.upstream_url.clone(),
+                        nested_result.upstream_ref.clone(),
+                        HashMap::new(), // template_vars handled below
+                        nested_result.merge_operations.clone(),
+                    );
+                    let residual = phase4::integrate_sub_composite_with_targets(
+                        &mut fs,
+                        &nested_intermediate,
+                        &mut accumulated_auto_merge_targets,
+                    )?;
 
                     merge_operations.extend(nested_result.merge_operations);
+                    merge_operations.extend(residual);
 
                     template_vars.extend(nested_result.template_vars);
                 } else {
@@ -186,8 +209,22 @@ fn resolve_repo_inline_inner(
             let child_result =
                 resolve_repo_inline_inner(child_cloned, cloned_repos, cache, visited)?;
 
-            fs.merge(&child_result.fs);
+            // Same auto-merge-aware integration for tree children
+            let child_intermediate = IntermediateFS::new_with_vars_and_merges(
+                child_result.fs.clone(),
+                child_result.upstream_url.clone(),
+                child_result.upstream_ref.clone(),
+                HashMap::new(),
+                child_result.merge_operations.clone(),
+            );
+            let residual = phase4::integrate_sub_composite_with_targets(
+                &mut fs,
+                &child_intermediate,
+                &mut accumulated_auto_merge_targets,
+            )?;
+
             merge_operations.extend(child_result.merge_operations);
+            merge_operations.extend(residual);
             template_vars.extend(child_result.template_vars);
         } else {
             warn!(
@@ -206,22 +243,41 @@ fn resolve_repo_inline_inner(
     ))
 }
 
+/// Whether the sequential pipeline is running for a `self:` block or a
+/// source block.
+///
+/// Both use [`execute_sequential_pipeline`], but differ in two ways:
+///
+/// 1. **Starting FS** — `SelfBlock` starts from local files (local files
+///    form the base of the composite). `SourceBlock` starts from an empty
+///    FS so that consumer-level operations (include, exclude, rename) only
+///    affect upstream content. Local files are combined in Phase 5 after
+///    the sequential pass.
+///
+/// 2. **Phase 5** — `SourceBlock` runs a Phase 5 merge to combine the
+///    composite with local files after the sequential pass. `SelfBlock`
+///    skips this because local files were already the starting base.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum PipelineMode {
+    SelfBlock,
+    SourceBlock,
+}
+
 /// Execute a sequential pipeline where operations fire in declaration order.
 ///
-/// Unlike [`execute_source_pipeline`] where Phases 2-4 process all repos in
-/// batch, this function walks the config's operations sequentially. When a
-/// `repo:` operation is encountered, it resolves inline at that position
-/// using [`resolve_repo_inline`] and [`phase4::integrate_sub_composite`].
+/// This function walks the config's operations sequentially. When a `repo:`
+/// operation is encountered, it resolves inline at that position using
+/// [`resolve_repo_inline`] and [`phase4::integrate_sub_composite`].
 ///
-/// This pipeline is used for `self:` blocks where the operation order
-/// matters: a preceding `include` or `rename` must transform the FS before
-/// a subsequent `repo:` integrates its sub-composite.
+/// Both `self:` and source blocks use this pipeline. See [`PipelineMode`]
+/// for the differences.
 fn execute_sequential_pipeline(
     config: &Schema,
     repo_manager: &RepositoryManager,
     cache: &RepoCache,
     working_dir: &Path,
     output_path: Option<&Path>,
+    mode: PipelineMode,
 ) -> Result<MemoryFS> {
     // Phase 1: Discover and clone repos eagerly
     let repo_tree = phase1::execute(config, repo_manager, cache)?;
@@ -229,8 +285,14 @@ fn execute_sequential_pipeline(
     // Build cloned_repos map for on-demand resolution
     let cloned_repos = phase2::clone_tree_repos(&repo_tree, repo_manager)?;
 
-    // Load local files from the working directory
-    let mut fs = phase5::load_local_fs(working_dir)?;
+    // Starting FS depends on pipeline mode:
+    // - SelfBlock: local files form the base. Upstream content overlays.
+    // - SourceBlock: empty FS. Consumer operations (include, exclude, rename)
+    //   affect only upstream content. Local files are combined in Phase 5.
+    let mut fs = match mode {
+        PipelineMode::SelfBlock => phase5::load_local_fs(working_dir)?,
+        PipelineMode::SourceBlock => MemoryFS::new(),
+    };
 
     let mut all_template_vars = HashMap::new();
     let mut residual_deferred_ops: Vec<Operation> = Vec::new();
@@ -238,6 +300,12 @@ fn execute_sequential_pipeline(
     // later repo can trigger format-aware merge for a file declared by an
     // earlier repo (or vice versa, when the later repo has defer: true).
     let mut accumulated_auto_merge_targets = HashMap::new();
+    // In source mode, snapshot upstream file content for auto-merge targets
+    // at the time each repo: fires. These snapshots survive subsequent
+    // consumer operations (e.g., exclude) and are used during Phase 5 to
+    // merge upstream content into local files that were not in the composite
+    // during the sequential pass.
+    let mut auto_merge_snapshots: HashMap<String, crate::filesystem::File> = HashMap::new();
 
     // Sequential pass: walk operations in declaration order
     for operation in config {
@@ -278,6 +346,20 @@ fn execute_sequential_pipeline(
                 if let Some(cloned) = cloned {
                     let sub_composite = resolve_repo_inline(cloned, &cloned_repos, cache)?;
 
+                    // In source mode, snapshot auto-merge source files BEFORE
+                    // integration. These snapshots survive subsequent consumer
+                    // ops (exclude, rename) and are used during Phase 5 to
+                    // merge upstream content into local files.
+                    if mode == PipelineMode::SourceBlock {
+                        for op in &sub_composite.merge_operations {
+                            if let Some(path) = phase4::get_auto_merge_path(op) {
+                                if let Some(file) = sub_composite.fs.get_file(path) {
+                                    auto_merge_snapshots.insert(path.to_string(), file.clone());
+                                }
+                            }
+                        }
+                    }
+
                     let residual = phase4::integrate_sub_composite_with_targets(
                         &mut fs,
                         &sub_composite,
@@ -285,7 +367,15 @@ fn execute_sequential_pipeline(
                     )?;
                     residual_deferred_ops.extend(residual);
 
-                    all_template_vars.extend(sub_composite.template_vars);
+                    // Upstream template vars fill in defaults but do not
+                    // overwrite consumer-level vars already set by a preceding
+                    // template-vars operation. This matches the old batch
+                    // pipeline where Phase 4 processed repos in post-order
+                    // (children before parents, local root last) and the local
+                    // root's consumer vars were the final write.
+                    for (key, value) in sub_composite.template_vars {
+                        all_template_vars.entry(key).or_insert(value);
+                    }
                 } else {
                     warn!(
                         "Repo reference not found in cloned repos, skipping: {}@{}",
@@ -305,6 +395,28 @@ fn execute_sequential_pipeline(
             | Operation::Ini { .. }
             | Operation::Markdown { .. }
             | Operation::Xml { .. } => {
+                // In source mode, the merge source and/or dest may be local
+                // files not yet in the composite. Load them from disk so the
+                // merge can reference them. This mirrors the old batch
+                // pipeline where Phase 5 loaded local files before running
+                // consumer merge operations.
+                if mode == PipelineMode::SourceBlock {
+                    for path in [
+                        operation.merge_effective_source(),
+                        operation.merge_effective_dest(),
+                    ]
+                    .into_iter()
+                    .flatten()
+                    {
+                        if !fs.exists(path) {
+                            let disk_path = working_dir.join(path);
+                            if disk_path.exists() {
+                                let content = std::fs::read(&disk_path)?;
+                                fs.add_file(path, crate::filesystem::File::new(content))?;
+                            }
+                        }
+                    }
+                }
                 phase4::execute_merge_operation(&mut fs, operation)?;
             }
             Operation::Tools { tools } => {
@@ -312,6 +424,46 @@ fn execute_sequential_pipeline(
             }
             Operation::Self_ { .. } => {}
         }
+    }
+
+    // Source blocks: Phase 5 — combine composite with local files.
+    // Local files that are not in the composite are preserved. Composite
+    // files win for shared paths (CompositePrecedence invariant). Auto-merge
+    // targets use format-aware merging instead of overwriting.
+    if mode == PipelineMode::SourceBlock {
+        let local_fs = phase5::load_local_fs(working_dir)?;
+        let mut combined = local_fs;
+        // Overlay composite on top of local files, with auto-merge awareness
+        phase4::merge_composite_with_auto_merge(
+            &mut combined,
+            &fs,
+            &accumulated_auto_merge_targets,
+        )?;
+
+        // Apply auto-merge snapshots for upstream files that were removed
+        // from the composite by consumer operations (e.g., exclude) after
+        // the repo: fired. The snapshots preserve the upstream's original
+        // file content so it can merge into local files even though the
+        // composite no longer contains it.
+        for (path, auto_merge_op) in &accumulated_auto_merge_targets {
+            // Skip paths still in the composite — handled by the overlay.
+            if fs.exists(path) {
+                continue;
+            }
+            // Merge snapshot into local file if both exist
+            if combined.exists(path) {
+                if let Some(snapshot_file) = auto_merge_snapshots.get(path) {
+                    let temp_path = format!(".__common_repo_auto_merge_snapshot__{}", path);
+                    combined.add_file(&temp_path, snapshot_file.clone())?;
+                    let explicit_op =
+                        phase4::make_explicit_merge_op(auto_merge_op, &temp_path, path);
+                    phase4::execute_merge_operation(&mut combined, &explicit_op)?;
+                    combined.remove_file(&temp_path)?;
+                }
+            }
+        }
+
+        fs = combined;
     }
 
     // Execute residual deferred merges (dest wasn't in the FS during integration)
@@ -330,55 +482,17 @@ fn execute_sequential_pipeline(
     Ok(fs)
 }
 
-/// Execute the source pipeline (Phases 1-6) for a given config.
+/// Execute the complete pull operation.
 ///
-/// This is the core pipeline logic, extracted so it can be called
-/// once for the main source config and again for each self: block.
-fn execute_source_pipeline(
-    config: &Schema,
-    repo_manager: &RepositoryManager,
-    cache: &RepoCache,
-    working_dir: &Path,
-    output_path: Option<&Path>,
-) -> Result<MemoryFS> {
-    // Phase 1: Discovery and Cloning
-    let repo_tree = phase1::execute(config, repo_manager, cache)?;
-
-    // Phase 2: Processing Individual Repos
-    let intermediate_fss = phase2::execute(&repo_tree, repo_manager, cache)?;
-
-    // Phase 3: Determining Operation Order
-    let operation_order = phase3::execute(&repo_tree)?;
-
-    // Phase 4: Composite Filesystem Construction
-    let (composite_fs, deferred_ops) = phase4::execute(&operation_order, &intermediate_fss)?;
-
-    // Phase 5: Local File Merging (receives deferred ops)
-    let final_fs = phase5::execute(&composite_fs, config, working_dir, &deferred_ops)?;
-
-    // Phase 6: Write to Disk (if output path provided)
-    if let Some(output) = output_path {
-        phase6::execute(&final_fs, output)?;
-    }
-
-    Ok(final_fs)
-}
-
-/// Execute the complete pull operation (Phases 1-6)
+/// Partitions the config into source and `self:` operations, then runs
+/// each through [`execute_sequential_pipeline`]. Both use the same
+/// sequential execution model where operations fire in YAML declaration
+/// order. The only difference is starting state:
 ///
-/// This orchestrates the complete inheritance pipeline:
-/// 1. Discover and clone repositories (with automatic caching)
-/// 2. Process each repository with its operations
-/// 3. Determine correct merge order
-/// 4. Merge into composite filesystem
-/// 5. Merge with local files and apply local operations
-/// 6. Write final filesystem to disk (if output_path is provided)
-///
-/// If the config contains `self:` blocks, they are partitioned out and
-/// run as independent pipeline invocations after the source pipeline
-/// completes. Self pipeline output is written to the working directory
-/// but never enters the composite filesystem that downstream consumers
-/// see.
+/// - Source blocks start from an empty FS and run Phase 5 (local merge)
+///   after the sequential pass.
+/// - `self:` blocks start from the local working directory and write
+///   directly.
 ///
 /// If `output_path` is `None`, returns the final MemoryFS without writing to disk.
 /// If `output_path` is `Some(path)`, writes to disk and returns the MemoryFS.
@@ -392,17 +506,18 @@ pub fn execute_pull(
     // Partition self: operations from source operations
     let (self_ops, source_config) = partition_self_operations(config);
 
-    // Run the source pipeline (main composite — what consumers see)
-    let final_fs = execute_source_pipeline(
+    // Run the source pipeline using the sequential model so operations
+    // execute in YAML declaration order (same code path as self: blocks).
+    let final_fs = execute_sequential_pipeline(
         &source_config,
         repo_manager,
         cache,
         working_dir,
         output_path,
+        PipelineMode::SourceBlock,
     )?;
 
-    // Run self: pipelines using sequential execution so repo: ops
-    // resolve inline at their declaration position.
+    // Run self: pipelines using the same sequential execution model.
     for self_op in &self_ops {
         execute_sequential_pipeline(
             &self_op.operations,
@@ -410,6 +525,7 @@ pub fn execute_pull(
             cache,
             working_dir,
             output_path,
+            PipelineMode::SelfBlock,
         )?;
     }
 

--- a/src/phases/ordering.rs
+++ b/src/phases/ordering.rs
@@ -33,6 +33,7 @@ use crate::error::Result;
 /// that base configurations are applied before derived ones.
 ///
 /// Returns an OperationOrder containing repository keys in merge order.
+#[allow(dead_code)]
 pub fn execute(tree: &RepoTree) -> Result<OperationOrder> {
     let mut order = Vec::new();
     let mut visited = HashSet::new();
@@ -48,6 +49,7 @@ pub fn execute(tree: &RepoTree) -> Result<OperationOrder> {
 /// This ensures that dependencies (children) are processed before their parents.
 /// The resulting order guarantees that base repositories are applied before
 /// repositories that depend on them.
+#[allow(dead_code)]
 fn build_order_recursive(node: &RepoNode, order: &mut Vec<String>, visited: &mut HashSet<String>) {
     let node_key = node.node_key();
 

--- a/src/phases/processing.rs
+++ b/src/phases/processing.rs
@@ -164,6 +164,7 @@ fn cache_key_for_cloned(cloned: &ClonedRepo) -> Result<Option<CacheKey>> {
 /// Internally delegates to [`clone_tree_repos`] and [`process_cloned_repo`]
 /// so the same per-repo processing logic is shared with the on-demand path
 /// used by the sequential pass.
+#[allow(dead_code)]
 pub fn execute(
     tree: &RepoTree,
     repo_manager: &RepositoryManager,
@@ -191,6 +192,7 @@ pub fn execute(
 }
 
 /// Process a single repository node into an intermediate filesystem
+#[allow(dead_code)]
 fn process_single_repo(
     node: &RepoNode,
     repo_manager: &RepositoryManager,
@@ -268,6 +270,7 @@ pub(crate) fn collect_merge_operations(operations: &[Operation]) -> Vec<Operatio
 }
 
 /// Build a cache key for a repository node (includes operations fingerprint)
+#[allow(dead_code)]
 fn cache_key_for_node(node: &RepoNode) -> Result<Option<CacheKey>> {
     if node.url == "local" {
         return Ok(None);

--- a/tests/cli_e2e_source_sequential.rs
+++ b/tests/cli_e2e_source_sequential.rs
@@ -1,0 +1,653 @@
+//! E2E tests for unified sequential execution in source blocks (issue #305).
+//!
+//! These tests validate that source blocks (top-level operations outside
+//! `self:`) use the same sequential execution model as `self:` blocks.
+//! Operations must execute in YAML declaration order — a rename between
+//! two `repo:` entries must affect what the second repo sees.
+//!
+//! All tests in this file target behaviour described by spec rules marked
+//! `@status: Partial` for issue #305:
+//!   - SequentialOperationExecution (common-repo.allium)
+//!   - BuildComposite (common-repo.allium)
+//!   - MergeLocalFiles (common-repo.allium)
+//!   - ApplyDeferredMerges (common-repo.allium)
+//!   - DeferredMergeAtDeclarationPosition (auto-merge-composition.allium)
+//!
+//! These tests FAIL on the current batch source pipeline and PASS once the
+//! source pipeline uses `execute_sequential_pipeline`.
+
+mod common;
+
+use assert_cmd::cargo::cargo_bin_cmd;
+use assert_fs::prelude::*;
+use common::init_test_git_repo;
+// =========================================================================
+// Spec: SequentialOperationExecution — rename between repos in source block
+// =========================================================================
+
+/// A rename between two repo: entries in a source block should affect the
+/// second repo's integration.
+///
+/// Setup:
+/// - upstream_a provides `old/data.txt`
+/// - upstream_b provides `old/data.txt` (different content)
+/// - Consumer source block: repo: A → rename old/ to new/ → repo: B
+///
+/// Sequential behavior (target): repo A integrates → rename moves
+/// `old/data.txt` to `new/data.txt` → repo B integrates `old/data.txt`
+/// again. Final FS has both `new/data.txt` (from A, renamed) and
+/// `old/data.txt` (from B, integrated after rename).
+///
+/// Batch behavior (current bug): all repos composite first, then rename
+/// runs — only `new/data.txt` exists because both A and B wrote to
+/// `old/data.txt` before rename ran.
+#[test]
+#[cfg_attr(not(feature = "integration-tests"), ignore)]
+fn test_source_rename_between_repos_affects_second_repo() {
+    let upstream_a = assert_fs::TempDir::new().unwrap();
+    init_test_git_repo(
+        &upstream_a,
+        &[
+            ("old/data.txt", "from_upstream_a\n"),
+            (".common-repo.yaml", "- include: [\"**\"]\n"),
+        ],
+        Some("v1.0.0"),
+    )
+    .unwrap();
+
+    let upstream_b = assert_fs::TempDir::new().unwrap();
+    init_test_git_repo(
+        &upstream_b,
+        &[
+            ("old/data.txt", "from_upstream_b\n"),
+            (".common-repo.yaml", "- include: [\"**\"]\n"),
+        ],
+        Some("v1.0.0"),
+    )
+    .unwrap();
+
+    let consumer = assert_fs::TempDir::new().unwrap();
+    let url_a = format!("file://{}", upstream_a.path().display());
+    let url_b = format!("file://{}", upstream_b.path().display());
+
+    let config = format!(
+        r#"- repo:
+    url: "{}"
+    ref: v1.0.0
+- rename:
+    - "^old/(.*)$": "new/$1"
+- repo:
+    url: "{}"
+    ref: v1.0.0
+"#,
+        url_a, url_b
+    );
+    consumer
+        .child(".common-repo.yaml")
+        .write_str(&config)
+        .unwrap();
+
+    let mut cmd = cargo_bin_cmd!("common-repo");
+    cmd.arg("apply")
+        .current_dir(consumer.path())
+        .assert()
+        .success();
+
+    // After sequential execution:
+    // 1. repo A → old/data.txt (from A) enters composite
+    // 2. rename → old/data.txt becomes new/data.txt
+    // 3. repo B → old/data.txt (from B) enters composite at old/data.txt
+
+    let new_data = consumer.path().join("new/data.txt");
+    assert!(
+        new_data.exists(),
+        "new/data.txt should exist (upstream A's file after rename).\n\
+         If this fails, rename did not run between the two repo: operations."
+    );
+    let new_content = std::fs::read_to_string(&new_data).unwrap();
+    assert!(
+        new_content.contains("from_upstream_a"),
+        "new/data.txt should contain upstream A's content.\nActual: {}",
+        new_content
+    );
+
+    let old_data = consumer.path().join("old/data.txt");
+    assert!(
+        old_data.exists(),
+        "old/data.txt should exist (upstream B integrated AFTER rename).\n\
+         This fails under the batch model because both repos are composited \
+         before rename runs, so only new/data.txt exists."
+    );
+    let old_content = std::fs::read_to_string(&old_data).unwrap();
+    assert!(
+        old_content.contains("from_upstream_b"),
+        "old/data.txt should contain upstream B's content.\nActual: {}",
+        old_content
+    );
+}
+
+// =========================================================================
+// Spec: SequentialOperationExecution — exclude between repos in source block
+// =========================================================================
+
+/// An exclude between two repo: entries in a source block should remove
+/// files before the second repo integrates.
+///
+/// Setup:
+/// - upstream_a provides `shared.txt` and `a_only.txt`
+/// - upstream_b provides `shared.txt` (different content)
+/// - Consumer source block: repo: A → exclude shared.txt → repo: B
+///
+/// Sequential: A integrates → exclude removes shared.txt → B integrates
+/// shared.txt. Final `shared.txt` is from B only.
+///
+/// Batch: all repos composite (B overwrites A's shared.txt via
+/// last-write-wins), then exclude removes shared.txt entirely.
+#[test]
+#[cfg_attr(not(feature = "integration-tests"), ignore)]
+fn test_source_exclude_between_repos() {
+    let upstream_a = assert_fs::TempDir::new().unwrap();
+    init_test_git_repo(
+        &upstream_a,
+        &[
+            ("shared.txt", "from_upstream_a\n"),
+            ("a_only.txt", "only_in_a\n"),
+            (".common-repo.yaml", "- include: [\"**\"]\n"),
+        ],
+        Some("v1.0.0"),
+    )
+    .unwrap();
+
+    let upstream_b = assert_fs::TempDir::new().unwrap();
+    init_test_git_repo(
+        &upstream_b,
+        &[
+            ("shared.txt", "from_upstream_b\n"),
+            (".common-repo.yaml", "- include: [\"**\"]\n"),
+        ],
+        Some("v1.0.0"),
+    )
+    .unwrap();
+
+    let consumer = assert_fs::TempDir::new().unwrap();
+    let url_a = format!("file://{}", upstream_a.path().display());
+    let url_b = format!("file://{}", upstream_b.path().display());
+
+    let config = format!(
+        r#"- repo:
+    url: "{}"
+    ref: v1.0.0
+- exclude:
+    - shared.txt
+- repo:
+    url: "{}"
+    ref: v1.0.0
+"#,
+        url_a, url_b
+    );
+    consumer
+        .child(".common-repo.yaml")
+        .write_str(&config)
+        .unwrap();
+
+    let mut cmd = cargo_bin_cmd!("common-repo");
+    cmd.arg("apply")
+        .current_dir(consumer.path())
+        .assert()
+        .success();
+
+    // Sequential: A's shared.txt excluded, then B re-introduces it.
+    // shared.txt should exist with B's content.
+    let shared = consumer.path().join("shared.txt");
+    assert!(
+        shared.exists(),
+        "shared.txt should exist (from B, integrated after exclude removed A's copy).\n\
+         Under batch model, exclude runs after all repos composite, removing it entirely."
+    );
+    let content = std::fs::read_to_string(&shared).unwrap();
+    assert!(
+        content.contains("from_upstream_b"),
+        "shared.txt should contain B's content.\nActual: {}",
+        content
+    );
+
+    // a_only.txt was excluded too (matches nothing in B, but was removed from A)
+    // Actually exclude pattern is "shared.txt" only, so a_only.txt survives
+    let a_only = consumer.path().join("a_only.txt");
+    assert!(
+        a_only.exists(),
+        "a_only.txt should survive (not matched by exclude pattern)"
+    );
+}
+
+// =========================================================================
+// Spec: SequentialOperationExecution — include between repos in source block
+// =========================================================================
+
+/// An include between two repo: entries in a source block should filter
+/// the composite at that point without affecting the second repo.
+///
+/// Setup:
+/// - upstream_a provides `keep.txt` and `drop.txt`
+/// - upstream_b provides `from_b.txt`
+/// - Consumer source block: repo: A → include keep.txt → repo: B
+///
+/// Sequential: A integrates (keep.txt + drop.txt) → include filters to
+/// keep.txt only → B integrates from_b.txt. Final FS: keep.txt + from_b.txt.
+///
+/// Batch: all repos composite, then include runs as post-processing,
+/// removing both drop.txt AND from_b.txt (only keep.txt survives).
+#[test]
+#[cfg_attr(not(feature = "integration-tests"), ignore)]
+fn test_source_include_between_repos() {
+    let upstream_a = assert_fs::TempDir::new().unwrap();
+    init_test_git_repo(
+        &upstream_a,
+        &[
+            ("keep.txt", "kept from A\n"),
+            ("drop.txt", "should be dropped by include\n"),
+            (".common-repo.yaml", "- include: [\"**\"]\n"),
+        ],
+        Some("v1.0.0"),
+    )
+    .unwrap();
+
+    let upstream_b = assert_fs::TempDir::new().unwrap();
+    init_test_git_repo(
+        &upstream_b,
+        &[
+            ("from_b.txt", "from upstream B\n"),
+            (".common-repo.yaml", "- include: [\"**\"]\n"),
+        ],
+        Some("v1.0.0"),
+    )
+    .unwrap();
+
+    let consumer = assert_fs::TempDir::new().unwrap();
+    let url_a = format!("file://{}", upstream_a.path().display());
+    let url_b = format!("file://{}", upstream_b.path().display());
+
+    let config = format!(
+        r#"- repo:
+    url: "{}"
+    ref: v1.0.0
+- include:
+    - "keep.txt"
+- repo:
+    url: "{}"
+    ref: v1.0.0
+"#,
+        url_a, url_b
+    );
+    consumer
+        .child(".common-repo.yaml")
+        .write_str(&config)
+        .unwrap();
+
+    let mut cmd = cargo_bin_cmd!("common-repo");
+    cmd.arg("apply")
+        .current_dir(consumer.path())
+        .assert()
+        .success();
+
+    // Sequential: include filters after A, before B integrates
+    assert!(
+        consumer.path().join("keep.txt").exists(),
+        "keep.txt should survive the include filter"
+    );
+    assert!(
+        !consumer.path().join("drop.txt").exists(),
+        "drop.txt should be removed by the include filter between repos"
+    );
+
+    // from_b.txt enters AFTER the include filter, so it should survive
+    let from_b = consumer.path().join("from_b.txt");
+    assert!(
+        from_b.exists(),
+        "from_b.txt should exist (repo B integrates after include filter).\n\
+         Under batch model, include runs after all repos composite and \
+         removes from_b.txt because it doesn't match the include pattern."
+    );
+}
+
+// =========================================================================
+// Spec: DeferredMergeAtDeclarationPosition — auto-merge at repo: position
+// =========================================================================
+
+/// Auto-merge operations from a sub-repo should fire at the repo:
+/// declaration position in a source block, not batched in Phase 5.
+///
+/// Setup:
+/// - upstream provides `config.yaml` via YAML auto-merge
+/// - Consumer has local `config.yaml` with local settings
+/// - Consumer source block: repo: upstream → exclude config.yaml
+///
+/// Sequential: repo: fires → auto-merge merges upstream config.yaml into
+/// local config.yaml → exclude removes the upstream's raw config.yaml
+/// (the merge fragment). Local config.yaml has merged content.
+///
+/// Batch: all repos composite, then Phase 5 runs deferred merges and
+/// consumer ops. The merged content survives but the execution order
+/// of exclude vs merge is not governed by declaration order.
+#[test]
+#[cfg_attr(not(feature = "integration-tests"), ignore)]
+fn test_source_auto_merge_fires_at_repo_declaration_position() {
+    let upstream = assert_fs::TempDir::new().unwrap();
+    init_test_git_repo(
+        &upstream,
+        &[
+            (
+                "config.yaml",
+                "settings:\n  from_upstream: true\n  log_level: info\n",
+            ),
+            (
+                ".common-repo.yaml",
+                "- include: [\"**\"]\n- yaml:\n    auto-merge: config.yaml\n",
+            ),
+        ],
+        Some("v1.0.0"),
+    )
+    .unwrap();
+
+    let consumer = assert_fs::TempDir::new().unwrap();
+    let upstream_url = format!("file://{}", upstream.path().display());
+
+    // Local config.yaml that the auto-merge should merge into
+    consumer
+        .child("config.yaml")
+        .write_str("settings:\n  local_only: true\n  app_name: my-app\n")
+        .unwrap();
+
+    let config = format!(
+        r#"- repo:
+    url: "{}"
+    ref: v1.0.0
+- exclude:
+    - "config.yaml"
+"#,
+        upstream_url
+    );
+    consumer
+        .child(".common-repo.yaml")
+        .write_str(&config)
+        .unwrap();
+
+    let mut cmd = cargo_bin_cmd!("common-repo");
+    cmd.arg("apply")
+        .current_dir(consumer.path())
+        .assert()
+        .success();
+
+    // In the sequential model, the repo: operation fires first, which
+    // triggers the auto-merge into local config.yaml. Then exclude removes
+    // the upstream's raw config.yaml from the composite. The local
+    // config.yaml should not be excluded because it's a local file, not
+    // a composite entry — but the key assertion is that auto-merge
+    // happened before exclude ran.
+    //
+    // Note: the exact behaviour of exclude on a merged file depends on
+    // implementation details. The primary assertion is that auto-merge
+    // content is present — proving it fired at the repo: position.
+    let config_path = consumer.path().join("config.yaml");
+    assert!(config_path.exists(), "config.yaml should exist after apply");
+
+    let content = std::fs::read_to_string(&config_path).unwrap();
+    assert!(
+        content.contains("local_only"),
+        "config.yaml should contain local settings.\nActual:\n{}",
+        content
+    );
+    assert!(
+        content.contains("from_upstream"),
+        "config.yaml should contain upstream settings via auto-merge.\n\
+         This proves auto-merge fired at the repo: declaration position.\n\
+         Actual:\n{}",
+        content
+    );
+}
+
+// =========================================================================
+// Spec: Parity — same config produces identical results in self: vs source
+// =========================================================================
+
+/// The same operation sequence should produce identical filesystem results
+/// whether it appears in a source block or a self: block.
+///
+/// This is the core parity test for issue #305. The only difference between
+/// self: and source is inheritance visibility — the execution model should
+/// be identical.
+///
+/// Setup: two upstreams both provide `old/data.txt`. Consumer uses
+/// repo A → rename old/ to new/ → repo B. Run once as source block,
+/// once as self: block, compare results.
+///
+/// Sequential (target): new/data.txt has A's content, old/data.txt has B's.
+/// Batch (current bug): new/data.txt has B's content (B overwrote A before
+/// rename ran), old/data.txt does not exist.
+#[test]
+#[cfg_attr(not(feature = "integration-tests"), ignore)]
+fn test_source_and_self_produce_identical_results() {
+    let upstream_a = assert_fs::TempDir::new().unwrap();
+    init_test_git_repo(
+        &upstream_a,
+        &[
+            ("old/data.txt", "from_a\n"),
+            (".common-repo.yaml", "- include: [\"**\"]\n"),
+        ],
+        Some("v1.0.0"),
+    )
+    .unwrap();
+
+    let upstream_b = assert_fs::TempDir::new().unwrap();
+    init_test_git_repo(
+        &upstream_b,
+        &[
+            ("old/data.txt", "from_b\n"),
+            (".common-repo.yaml", "- include: [\"**\"]\n"),
+        ],
+        Some("v1.0.0"),
+    )
+    .unwrap();
+
+    let url_a = format!("file://{}", upstream_a.path().display());
+    let url_b = format!("file://{}", upstream_b.path().display());
+
+    // Operations: repo A → rename old/ to new/ → repo B
+    // Sequential result: new/data.txt (A), old/data.txt (B)
+
+    // --- Run as source block ---
+    let consumer_source = assert_fs::TempDir::new().unwrap();
+    let source_config = format!(
+        r#"- repo:
+    url: "{}"
+    ref: v1.0.0
+- rename:
+    - "^old/(.*)$": "new/$1"
+- repo:
+    url: "{}"
+    ref: v1.0.0
+"#,
+        url_a, url_b
+    );
+    consumer_source
+        .child(".common-repo.yaml")
+        .write_str(&source_config)
+        .unwrap();
+
+    let mut cmd = cargo_bin_cmd!("common-repo");
+    cmd.arg("apply")
+        .current_dir(consumer_source.path())
+        .assert()
+        .success();
+
+    // --- Run as self: block ---
+    let consumer_self = assert_fs::TempDir::new().unwrap();
+    let self_config = format!(
+        r#"- self:
+  - repo:
+      url: "{}"
+      ref: v1.0.0
+  - rename:
+      - "^old/(.*)$": "new/$1"
+  - repo:
+      url: "{}"
+      ref: v1.0.0
+"#,
+        url_a, url_b
+    );
+    consumer_self
+        .child(".common-repo.yaml")
+        .write_str(&self_config)
+        .unwrap();
+
+    let mut cmd = cargo_bin_cmd!("common-repo");
+    cmd.arg("apply")
+        .current_dir(consumer_self.path())
+        .assert()
+        .success();
+
+    // --- Compare results ---
+    // Both should have new/data.txt (from A, renamed) and old/data.txt (from B)
+
+    // Self: block (known-good sequential behavior)
+    assert!(
+        consumer_self.path().join("new/data.txt").exists(),
+        "self: block: new/data.txt should exist (A's file after rename)"
+    );
+    assert!(
+        consumer_self.path().join("old/data.txt").exists(),
+        "self: block: old/data.txt should exist (B integrated after rename)"
+    );
+
+    let self_new = std::fs::read_to_string(consumer_self.path().join("new/data.txt")).unwrap();
+    let self_old = std::fs::read_to_string(consumer_self.path().join("old/data.txt")).unwrap();
+    assert!(
+        self_new.contains("from_a"),
+        "self: new/data.txt should be from A"
+    );
+    assert!(
+        self_old.contains("from_b"),
+        "self: old/data.txt should be from B"
+    );
+
+    // Source block should produce identical results
+    assert!(
+        consumer_source.path().join("new/data.txt").exists(),
+        "source block: new/data.txt should exist (A's file after rename).\n\
+         Under batch model, this contains B's content instead of A's."
+    );
+    assert!(
+        consumer_source.path().join("old/data.txt").exists(),
+        "source block: old/data.txt should exist (B integrated after rename).\n\
+         Under batch model, old/data.txt does not exist because rename \
+         moved it to new/ after both repos were composited."
+    );
+
+    let source_new = std::fs::read_to_string(consumer_source.path().join("new/data.txt")).unwrap();
+    let source_old = std::fs::read_to_string(consumer_source.path().join("old/data.txt")).unwrap();
+
+    assert_eq!(
+        source_new, self_new,
+        "new/data.txt content should be identical between source and self: blocks"
+    );
+    assert_eq!(
+        source_old, self_old,
+        "old/data.txt content should be identical between source and self: blocks"
+    );
+}
+
+// =========================================================================
+// Spec: BuildComposite — sequential composite with multiple auto-merges
+// =========================================================================
+
+/// Multiple repo: operations in a source block with auto-merge should
+/// accumulate content sequentially, each seeing the prior repo's merged
+/// result.
+///
+/// This mirrors test_self_block_multiple_repo_ops_with_auto_merge from
+/// cli_e2e_repo_in_sequence.rs but runs in a source block instead of self:.
+#[test]
+#[cfg_attr(not(feature = "integration-tests"), ignore)]
+fn test_source_multiple_repos_with_auto_merge_accumulate() {
+    let upstream_a = assert_fs::TempDir::new().unwrap();
+    init_test_git_repo(
+        &upstream_a,
+        &[
+            ("config.yaml", "settings:\n  from_a: true\n"),
+            (
+                ".common-repo.yaml",
+                "- include: [\"**\"]\n- yaml:\n    auto-merge: config.yaml\n",
+            ),
+        ],
+        Some("v1.0.0"),
+    )
+    .unwrap();
+
+    let upstream_b = assert_fs::TempDir::new().unwrap();
+    init_test_git_repo(
+        &upstream_b,
+        &[
+            ("config.yaml", "settings:\n  from_b: true\n"),
+            (
+                ".common-repo.yaml",
+                "- include: [\"**\"]\n- yaml:\n    auto-merge: config.yaml\n",
+            ),
+        ],
+        Some("v1.0.0"),
+    )
+    .unwrap();
+
+    let consumer = assert_fs::TempDir::new().unwrap();
+    let url_a = format!("file://{}", upstream_a.path().display());
+    let url_b = format!("file://{}", upstream_b.path().display());
+
+    // Local config that both upstreams should merge into
+    consumer
+        .child("config.yaml")
+        .write_str("settings:\n  local: true\n")
+        .unwrap();
+
+    let config = format!(
+        r#"- repo:
+    url: "{}"
+    ref: v1.0.0
+- repo:
+    url: "{}"
+    ref: v1.0.0
+"#,
+        url_a, url_b
+    );
+    consumer
+        .child(".common-repo.yaml")
+        .write_str(&config)
+        .unwrap();
+
+    let mut cmd = cargo_bin_cmd!("common-repo");
+    cmd.arg("apply")
+        .current_dir(consumer.path())
+        .assert()
+        .success();
+
+    let config_path = consumer.path().join("config.yaml");
+    assert!(config_path.exists(), "config.yaml should exist");
+
+    let content = std::fs::read_to_string(&config_path).unwrap();
+
+    // All three sources of settings should be present
+    assert!(
+        content.contains("local"),
+        "Should contain local settings.\nActual:\n{}",
+        content
+    );
+    assert!(
+        content.contains("from_a"),
+        "Should contain upstream A settings via auto-merge.\nActual:\n{}",
+        content
+    );
+    assert!(
+        content.contains("from_b"),
+        "Should contain upstream B settings via auto-merge.\n\
+         Both repos' auto-merges should accumulate sequentially.\nActual:\n{}",
+        content
+    );
+}


### PR DESCRIPTION
## Summary

- Replace the batch source pipeline (`execute_source_pipeline`) with `execute_sequential_pipeline` parameterized by a `PipelineMode` enum, so both source and `self:` blocks execute operations in YAML declaration order
- Source blocks start from an empty FS and run Phase 5 (local merge) afterward; `self:` blocks start from local files and write directly — same code path, different starting state
- Fix `resolve_repo_inline_inner` to use auto-merge-aware integration for nested repos, fixing cross-upstream auto-merge accumulation

Closes #305

## What changed

**`src/phases/orchestrator.rs`** (primary):
- Removed `execute_source_pipeline` (batch pipeline)
- Added `PipelineMode` enum (`SelfBlock` / `SourceBlock`)
- `execute_pull` now routes both block types through `execute_sequential_pipeline`
- Source mode: snapshots auto-merge files before integration, loads local merge sources from disk, runs Phase 5 overlay with auto-merge awareness

**`src/phases/composite.rs`**: Exposed `get_auto_merge_path`, `make_explicit_merge_op` as `pub(crate)`, added `merge_composite_with_auto_merge` wrapper

**`spec/common-repo.allium`**: Updated 4 rules from `@status: Partial` to `@status: Implemented`, clarified both block types use `execute_sequential_pipeline`

**`spec/detailed/auto-merge-composition.allium`**: Updated `DeferredMergeAtDeclarationPosition` from `@status: Partial` to `@status: Implemented`

**`tests/cli_e2e_source_sequential.rs`** (new): 6 E2E tests validating sequential source block behavior:
- Rename between repos affects second repo
- Exclude between repos removes files before next repo
- Include between repos filters without affecting later repos
- Auto-merge fires at `repo:` declaration position
- Source/self: parity (identical config produces identical results)
- Multiple auto-merges accumulate with local content preserved

## Test plan

- [x] All 6 new `cli_e2e_source_sequential` tests pass
- [x] All existing `cli_e2e_repo_in_sequence` tests pass (self: block backward compat)
- [x] All existing `cli_e2e_sequential_ops` tests pass (consumer ops backward compat)
- [x] Full test suite: 1333/1334 pass (1 unrelated network timeout in isolation)
- [x] `./script/ci` passes (fmt, clippy, prose, pre-commit)