### PR TITLE
refactor(merge): deduplicate file I/O helpers across format modules

### DIFF
--- a/src/merge/ini.rs
+++ b/src/merge/ini.rs
@@ -28,9 +28,15 @@ use std::collections::HashSet;
 
 use log::warn;
 
+use super::{read_file_as_string, read_file_as_string_optional, write_string_to_file};
 use crate::config::IniMergeOp;
-use crate::error::{Error, Result};
-use crate::filesystem::{File, MemoryFS};
+use crate::error::Result;
+use crate::filesystem::MemoryFS;
+
+#[cfg(test)]
+use super::ensure_trailing_newline;
+#[cfg(test)]
+use crate::filesystem::File;
 
 /// Represents a key-value entry in an INI file
 #[derive(Clone, Debug)]
@@ -279,46 +285,6 @@ pub fn apply_ini_merge_operation(fs: &mut MemoryFS, op: &IniMergeOp) -> Result<(
 
     let serialized = serialize_ini(&dest_sections);
     write_string_to_file(fs, dest_path, serialized)
-}
-
-// File I/O helpers
-
-fn read_file_as_string(fs: &MemoryFS, path: &str) -> Result<String> {
-    match fs.get_file(path) {
-        Some(file) => String::from_utf8(file.content.clone()).map_err(|_| Error::Merge {
-            operation: format!("read {}", path),
-            message: "File content is not valid UTF-8".to_string(),
-        }),
-        None => Err(Error::Merge {
-            operation: format!("read {}", path),
-            message: "File not found in filesystem. Was it possibly renamed or excluded by a preceding operation?".to_string(),
-        }),
-    }
-}
-
-fn read_file_as_string_optional(fs: &MemoryFS, path: &str) -> Result<Option<String>> {
-    if let Some(file) = fs.get_file(path) {
-        Ok(Some(String::from_utf8(file.content.clone()).map_err(
-            |_| Error::Merge {
-                operation: format!("read {}", path),
-                message: "File content is not valid UTF-8".to_string(),
-            },
-        )?))
-    } else {
-        Ok(None)
-    }
-}
-
-fn ensure_trailing_newline(mut content: String) -> String {
-    if !content.ends_with('\n') {
-        content.push('\n');
-    }
-    content
-}
-
-fn write_string_to_file(fs: &mut MemoryFS, path: &str, content: String) -> Result<()> {
-    let normalized = ensure_trailing_newline(content);
-    fs.add_file(path, File::from_string(&normalized))
 }
 
 #[cfg(test)]

--- a/src/merge/json.rs
+++ b/src/merge/json.rs
@@ -25,10 +25,15 @@
 use log::warn;
 use serde_json::Value as JsonValue;
 
-use super::PathSegment;
+use super::{read_file_as_string, read_file_as_string_optional, write_string_to_file, PathSegment};
 use crate::config::{ArrayMergeMode, InsertPosition, JsonMergeOp};
 use crate::error::{Error, Result};
-use crate::filesystem::{File, MemoryFS};
+use crate::filesystem::MemoryFS;
+
+#[cfg(test)]
+use super::ensure_trailing_newline;
+#[cfg(test)]
+use crate::filesystem::File;
 
 /// Navigate to a specific path within a JSON value, creating intermediate
 /// structures as needed.
@@ -373,46 +378,6 @@ pub fn apply_json_merge_operation(fs: &mut MemoryFS, op: &JsonMergeOp) -> Result
     })?;
 
     write_string_to_file(fs, dest_path, serialized)
-}
-
-// File I/O helpers
-
-fn read_file_as_string(fs: &MemoryFS, path: &str) -> Result<String> {
-    match fs.get_file(path) {
-        Some(file) => String::from_utf8(file.content.clone()).map_err(|_| Error::Merge {
-            operation: format!("read {}", path),
-            message: "File content is not valid UTF-8".to_string(),
-        }),
-        None => Err(Error::Merge {
-            operation: format!("read {}", path),
-            message: "File not found in filesystem. Was it possibly renamed or excluded by a preceding operation?".to_string(),
-        }),
-    }
-}
-
-fn read_file_as_string_optional(fs: &MemoryFS, path: &str) -> Result<Option<String>> {
-    if let Some(file) = fs.get_file(path) {
-        Ok(Some(String::from_utf8(file.content.clone()).map_err(
-            |_| Error::Merge {
-                operation: format!("read {}", path),
-                message: "File content is not valid UTF-8".to_string(),
-            },
-        )?))
-    } else {
-        Ok(None)
-    }
-}
-
-fn ensure_trailing_newline(mut content: String) -> String {
-    if !content.ends_with('\n') {
-        content.push('\n');
-    }
-    content
-}
-
-fn write_string_to_file(fs: &mut MemoryFS, path: &str, content: String) -> Result<()> {
-    let normalized = ensure_trailing_newline(content);
-    fs.add_file(path, File::from_string(&normalized))
 }
 
 #[cfg(test)]

--- a/src/merge/markdown.rs
+++ b/src/merge/markdown.rs
@@ -26,9 +26,15 @@
 
 use log::warn;
 
+use super::{read_file_as_string, read_file_as_string_optional, write_string_to_file};
 use crate::config::{InsertPosition, MarkdownMergeOp};
 use crate::error::{Error, Result};
-use crate::filesystem::{File, MemoryFS};
+use crate::filesystem::MemoryFS;
+
+#[cfg(test)]
+use super::ensure_trailing_newline;
+#[cfg(test)]
+use crate::filesystem::File;
 
 /// Split content into lines while preserving trailing newline information
 ///
@@ -213,46 +219,6 @@ pub fn apply_markdown_merge_operation(fs: &mut MemoryFS, op: &MarkdownMergeOp) -
     }
 
     write_string_to_file(fs, dest_path, serialized)
-}
-
-// File I/O helpers
-
-fn read_file_as_string(fs: &MemoryFS, path: &str) -> Result<String> {
-    match fs.get_file(path) {
-        Some(file) => String::from_utf8(file.content.clone()).map_err(|_| Error::Merge {
-            operation: format!("read {}", path),
-            message: "File content is not valid UTF-8".to_string(),
-        }),
-        None => Err(Error::Merge {
-            operation: format!("read {}", path),
-            message: "File not found in filesystem. Was it possibly renamed or excluded by a preceding operation?".to_string(),
-        }),
-    }
-}
-
-fn read_file_as_string_optional(fs: &MemoryFS, path: &str) -> Result<Option<String>> {
-    if let Some(file) = fs.get_file(path) {
-        Ok(Some(String::from_utf8(file.content.clone()).map_err(
-            |_| Error::Merge {
-                operation: format!("read {}", path),
-                message: "File content is not valid UTF-8".to_string(),
-            },
-        )?))
-    } else {
-        Ok(None)
-    }
-}
-
-fn ensure_trailing_newline(mut content: String) -> String {
-    if !content.ends_with('\n') {
-        content.push('\n');
-    }
-    content
-}
-
-fn write_string_to_file(fs: &mut MemoryFS, path: &str, content: String) -> Result<()> {
-    let normalized = ensure_trailing_newline(content);
-    fs.add_file(path, File::from_string(&normalized))
 }
 
 #[cfg(test)]

--- a/src/merge/mod.rs
+++ b/src/merge/mod.rs
@@ -17,6 +17,9 @@
 //! The `PathSegment` enum and path parsing functions are shared across formats
 //! to navigate nested data structures during merge operations.
 
+use crate::error::{Error, Result};
+use crate::filesystem::{File, MemoryFS};
+
 // Merge format modules - internal implementations
 // These are called by the phases module during merge operations
 pub(crate) mod ini;
@@ -148,6 +151,46 @@ pub fn parse_path(path: &str) -> Vec<PathSegment> {
     }
 
     segments
+}
+
+// Shared file I/O helpers used by all merge format modules.
+
+pub(super) fn read_file_as_string(fs: &MemoryFS, path: &str) -> Result<String> {
+    match fs.get_file(path) {
+        Some(file) => String::from_utf8(file.content.clone()).map_err(|_| Error::Merge {
+            operation: format!("read {}", path),
+            message: "File content is not valid UTF-8".to_string(),
+        }),
+        None => Err(Error::Merge {
+            operation: format!("read {}", path),
+            message: "File not found in filesystem. Was it possibly renamed or excluded by a preceding operation?".to_string(),
+        }),
+    }
+}
+
+pub(super) fn read_file_as_string_optional(fs: &MemoryFS, path: &str) -> Result<Option<String>> {
+    if let Some(file) = fs.get_file(path) {
+        Ok(Some(String::from_utf8(file.content.clone()).map_err(
+            |_| Error::Merge {
+                operation: format!("read {}", path),
+                message: "File content is not valid UTF-8".to_string(),
+            },
+        )?))
+    } else {
+        Ok(None)
+    }
+}
+
+pub(super) fn ensure_trailing_newline(mut content: String) -> String {
+    if !content.ends_with('\n') {
+        content.push('\n');
+    }
+    content
+}
+
+pub(super) fn write_string_to_file(fs: &mut MemoryFS, path: &str, content: String) -> Result<()> {
+    let normalized = ensure_trailing_newline(content);
+    fs.add_file(path, File::from_string(&normalized))
 }
 
 #[cfg(test)]

--- a/src/merge/toml.rs
+++ b/src/merge/toml.rs
@@ -26,10 +26,15 @@
 use log::warn;
 use toml::Value as TomlValue;
 
-use super::PathSegment;
+use super::{read_file_as_string, read_file_as_string_optional, write_string_to_file, PathSegment};
 use crate::config::TomlMergeOp;
 use crate::error::{Error, Result};
-use crate::filesystem::{File, MemoryFS};
+use crate::filesystem::MemoryFS;
+
+#[cfg(test)]
+use super::ensure_trailing_newline;
+#[cfg(test)]
+use crate::filesystem::File;
 
 /// Parse a TOML path string into segments for navigation
 ///
@@ -455,46 +460,6 @@ pub fn apply_toml_merge_operation(fs: &mut MemoryFS, op: &TomlMergeOp) -> Result
     };
 
     write_string_to_file(fs, dest_path, serialized)
-}
-
-// File I/O helpers
-
-fn read_file_as_string(fs: &MemoryFS, path: &str) -> Result<String> {
-    match fs.get_file(path) {
-        Some(file) => String::from_utf8(file.content.clone()).map_err(|_| Error::Merge {
-            operation: format!("read {}", path),
-            message: "File content is not valid UTF-8".to_string(),
-        }),
-        None => Err(Error::Merge {
-            operation: format!("read {}", path),
-            message: "File not found in filesystem. Was it possibly renamed or excluded by a preceding operation?".to_string(),
-        }),
-    }
-}
-
-fn read_file_as_string_optional(fs: &MemoryFS, path: &str) -> Result<Option<String>> {
-    if let Some(file) = fs.get_file(path) {
-        Ok(Some(String::from_utf8(file.content.clone()).map_err(
-            |_| Error::Merge {
-                operation: format!("read {}", path),
-                message: "File content is not valid UTF-8".to_string(),
-            },
-        )?))
-    } else {
-        Ok(None)
-    }
-}
-
-fn ensure_trailing_newline(mut content: String) -> String {
-    if !content.ends_with('\n') {
-        content.push('\n');
-    }
-    content
-}
-
-fn write_string_to_file(fs: &mut MemoryFS, path: &str, content: String) -> Result<()> {
-    let normalized = ensure_trailing_newline(content);
-    fs.add_file(path, File::from_string(&normalized))
 }
 
 #[cfg(test)]

--- a/src/merge/xml.rs
+++ b/src/merge/xml.rs
@@ -6,10 +6,13 @@
 use log::warn;
 use xot::Xot;
 
-use super::PathSegment;
+use super::{read_file_as_string, read_file_as_string_optional, write_string_to_file, PathSegment};
 use crate::config::{ArrayMergeMode, InsertPosition, XmlMergeOp};
 use crate::error::{Error, Result};
-use crate::filesystem::{File, MemoryFS};
+use crate::filesystem::MemoryFS;
+
+#[cfg(test)]
+use crate::filesystem::File;
 
 /// Context for XML merge operations, bundling diagnostic metadata.
 pub(crate) struct XmlMergeContext<'a> {
@@ -417,46 +420,6 @@ pub fn apply_xml_merge_operation(fs: &mut MemoryFS, op: &XmlMergeOp) -> Result<(
         })?;
 
     write_string_to_file(fs, dest_path, serialized)
-}
-
-// File I/O helpers (same pattern as json.rs)
-
-fn read_file_as_string(fs: &MemoryFS, path: &str) -> Result<String> {
-    match fs.get_file(path) {
-        Some(file) => String::from_utf8(file.content.clone()).map_err(|_| Error::Merge {
-            operation: format!("read {}", path),
-            message: "File content is not valid UTF-8".to_string(),
-        }),
-        None => Err(Error::Merge {
-            operation: format!("read {}", path),
-            message: "File not found in filesystem. Was it possibly renamed or excluded by a preceding operation?".to_string(),
-        }),
-    }
-}
-
-fn read_file_as_string_optional(fs: &MemoryFS, path: &str) -> Result<Option<String>> {
-    if let Some(file) = fs.get_file(path) {
-        Ok(Some(String::from_utf8(file.content.clone()).map_err(
-            |_| Error::Merge {
-                operation: format!("read {}", path),
-                message: "File content is not valid UTF-8".to_string(),
-            },
-        )?))
-    } else {
-        Ok(None)
-    }
-}
-
-fn ensure_trailing_newline(mut content: String) -> String {
-    if !content.ends_with('\n') {
-        content.push('\n');
-    }
-    content
-}
-
-fn write_string_to_file(fs: &mut MemoryFS, path: &str, content: String) -> Result<()> {
-    let normalized = ensure_trailing_newline(content);
-    fs.add_file(path, File::from_string(&normalized))
 }
 
 #[cfg(test)]

--- a/src/merge/yaml.rs
+++ b/src/merge/yaml.rs
@@ -26,10 +26,15 @@
 use log::warn;
 use serde_yaml::Value as YamlValue;
 
-use super::PathSegment;
+use super::{read_file_as_string, read_file_as_string_optional, write_string_to_file, PathSegment};
 use crate::config::{ArrayMergeMode, InsertPosition, YamlMergeOp};
 use crate::error::{Error, Result};
-use crate::filesystem::{File, MemoryFS};
+use crate::filesystem::MemoryFS;
+
+#[cfg(test)]
+use super::ensure_trailing_newline;
+#[cfg(test)]
+use crate::filesystem::File;
 
 /// Navigate to a specific path within a YAML value, creating intermediate
 /// structures as needed.
@@ -364,46 +369,6 @@ pub fn apply_yaml_merge_operation(fs: &mut MemoryFS, op: &YamlMergeOp) -> Result
     })?;
 
     write_string_to_file(fs, dest_path, serialized)
-}
-
-// File I/O helpers
-
-fn read_file_as_string(fs: &MemoryFS, path: &str) -> Result<String> {
-    match fs.get_file(path) {
-        Some(file) => String::from_utf8(file.content.clone()).map_err(|_| Error::Merge {
-            operation: format!("read {}", path),
-            message: "File content is not valid UTF-8".to_string(),
-        }),
-        None => Err(Error::Merge {
-            operation: format!("read {}", path),
-            message: "File not found in filesystem. Was it possibly renamed or excluded by a preceding operation?".to_string(),
-        }),
-    }
-}
-
-fn read_file_as_string_optional(fs: &MemoryFS, path: &str) -> Result<Option<String>> {
-    if let Some(file) = fs.get_file(path) {
-        Ok(Some(String::from_utf8(file.content.clone()).map_err(
-            |_| Error::Merge {
-                operation: format!("read {}", path),
-                message: "File content is not valid UTF-8".to_string(),
-            },
-        )?))
-    } else {
-        Ok(None)
-    }
-}
-
-fn ensure_trailing_newline(mut content: String) -> String {
-    if !content.ends_with('\n') {
-        content.push('\n');
-    }
-    content
-}
-
-fn write_string_to_file(fs: &mut MemoryFS, path: &str, content: String) -> Result<()> {
-    let normalized = ensure_trailing_newline(content);
-    fs.add_file(path, File::from_string(&normalized))
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary

- Extracted 4 identical file I/O helper functions (`read_file_as_string`, `read_file_as_string_optional`, `ensure_trailing_newline`, `write_string_to_file`) that were copy-pasted across all 6 merge format modules (json, yaml, toml, ini, markdown, xml) into a single shared definition in `merge/mod.rs`
- Net reduction of 167 lines (84 added, 251 removed) with zero behavior change
- All 1071 tests pass, clippy clean, formatted

## Motivation

Each merge format module had its own private copy of the same 4 file I/O helpers -- byte-for-byte identical across all 6 files. This made maintenance harder (any fix had to be replicated 6 times) and obscured the actual format-specific logic in each module.

## What changed

- `src/merge/mod.rs`: Added shared `pub(super)` helpers with the necessary `use` imports
- `src/merge/{json,yaml,toml,ini,markdown,xml}.rs`: Removed local copies, added `use super::` imports; moved test-only imports (`File`, `ensure_trailing_newline`) behind `#[cfg(test)]`

## Test plan

- [x] `cargo nextest run` -- 1071 passed, 266 skipped
- [x] `cargo clippy --all-targets --all-features -- -D warnings` -- clean
- [x] `cargo fmt` -- clean


Made with [Cursor](https://cursor.com)