### PR TITLE
feat(include): add if-exists field to control destination collisions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+- - -
+
 ## [0.36.0](https://github.com/common-repo/common-repo/compare/v0.35.0...v0.36.0) (2026-04-15)
 
 

--- a/docs/src/authoring-upstream-repos.md
+++ b/docs/src/authoring-upstream-repos.md
@@ -170,7 +170,7 @@ Upstream repository config files (`.common-repo.yaml` and `.commonrepo.yaml`) ar
 
 ## Upstream-Declared Merge Behavior
 
-By default, files from upstream repositories overwrite files in consumer repositories. However, upstream authors often know best how their files should integrate. The **defer** mechanism allows upstream repos to declare merge behavior that automatically applies when consumers inherit from them.
+By default, files from upstream repositories overwrite files in consumer repositories. Upstream repos can declare `if-exists: preserve` on `include:` operators so consumers automatically keep their local version of a file without needing to fork or add an override in their own config. However, upstream authors often know best how their files should integrate. The **defer** mechanism allows upstream repos to declare merge behavior that automatically applies when consumers inherit from them.
 
 ### When to Use Upstream-Declared Merges
 

--- a/docs/src/configuration.md
+++ b/docs/src/configuration.md
@@ -154,11 +154,25 @@ consumer's working tree at write time:
   when local content at the destination should be a hard signal that the
   consumer's setup needs attention.
 
-Example:
+"Exists" means any filesystem entry at the destination path on disk — a
+regular file, a symlink (valid or broken), or a directory. The check
+uses on-disk metadata, so it detects entries that would be invisible to
+a plain file walk.
+
+Example using `preserve`:
 
 ```yaml
 - include: [".github/workflows/ci.yaml"]
   if-exists: preserve
+```
+
+Example using `error` — choose this when the destination holds content
+that must not be silently replaced, such as production credentials
+shipped via `include:` from a template repo:
+
+```yaml
+- include: ["sensitive/config.yaml"]
+  if-exists: error
 ```
 
 `if-exists:` works the same way inside a `repo:` block's `with:` clause:
@@ -199,17 +213,22 @@ declare the merge.
 
 #### Unknown sibling keys
 
-A typo in an operator-level sibling key (for example, `if-exits:`)
-in **original-format** YAML produces a `log::warn!` at default
-visibility and is otherwise ignored. The warning is non-fatal so a
-consumer pulling from a misconfigured upstream is not hard-blocked by
-the upstream's typo.
+A typo in an operator-level sibling key (for example, `if-exits:`
+instead of `if-exists:`) does not abort propagation. Whether the typo
+is caught depends on which YAML form the config uses:
 
-The standard YAML format goes through a derived deserializer that
-silently drops unknown fields. Typos in standard-format configuration
-parse as if the unknown key were absent (so `if-exits: preserve`
-produces no warning and `if_exists` falls back to its default
-`Overwrite`).
+- **Legacy bare-mapping form** (the original parser, where the operator
+  key and its siblings are direct children of a list-entry mapping):
+  emits a `log::warn!` at default visibility naming the unknown key.
+  The key is dropped and propagation continues.
+- **Standard form** (serde's derived deserializer): silently ignores
+  unknown fields. A typo parses as if the key were absent, so
+  `if-exits: preserve` produces no warning and `if_exists` falls back
+  to its default `Overwrite`.
+
+Most consumer configs are written in the legacy bare-mapping form, so
+the warning fires for typos. Configs in standard form should be
+reviewed manually — serde will not flag unknown keys.
 
 ### `exclude` - Remove Files
 

--- a/docs/src/configuration.md
+++ b/docs/src/configuration.md
@@ -139,6 +139,78 @@ Add files from the current repository to the output based on glob patterns.
 - `.*` - Hidden files (dotfiles) at root
 - `.*/**/*` - All files in hidden directories
 
+#### `if-exists:` — control over destination collisions
+
+The optional `if-exists:` sibling key on an `include:` operator chooses what
+happens when an included file's destination already exists in the
+consumer's working tree at write time:
+
+- `overwrite` (default): the include result clobbers any local content at
+  the destination. Equivalent to omitting `if-exists:`.
+- `preserve`: skip the write so the consumer's content survives. Useful
+  when an upstream ships a sensible-default file the consumer is free to
+  customise (for example, a stub CI workflow).
+- `error`: fail propagation with a clear error naming the path. Useful
+  when local content at the destination should be a hard signal that the
+  consumer's setup needs attention.
+
+Example:
+
+```yaml
+- include: [".github/workflows/ci.yaml"]
+  if-exists: preserve
+```
+
+`if-exists:` works the same way inside a `repo:` block's `with:` clause:
+
+```yaml
+- repo:
+    url: https://github.com/common-repo/semantic-release
+    ref: v1.0.0
+    with:
+      - include: ["**"]
+        if-exists: preserve
+```
+
+#### Last-op-wins
+
+Multiple operators on the same path follow last-op-wins by **execution
+order**. A later non-deferred operator (including the `Overwrite`-tagged
+output of a merge operator) replaces an earlier `Preserve` tag at the
+same destination.
+
+#### Interaction with upstream `auto-merge:`
+
+`if-exists: preserve` does **not** opt out of an upstream `auto-merge:`
+declaration. Auto-merge operations are deferred — they run at the
+residual stage, after the consumer's sequential pass. The merge produces
+a fresh file with the default `Overwrite` tag at the destination,
+clobbering any preceding `Preserve` tag.
+
+A consumer-side `exclude:` likewise does not suppress an upstream
+`auto-merge:`. The exclude removes the file from the composite, but the
+deferred merge captures a snapshot of the upstream file at integration
+time and merges that snapshot into the local file regardless.
+
+The reliable way to avoid an upstream `auto-merge:` for a particular
+file is to remove the merge declaration upstream — either by working
+with the upstream maintainer, or by depending on a fork that does not
+declare the merge.
+
+#### Unknown sibling keys
+
+A typo in an operator-level sibling key (for example, `if-exits:`)
+in **original-format** YAML produces a `log::warn!` at default
+visibility and is otherwise ignored. The warning is non-fatal so a
+consumer pulling from a misconfigured upstream is not hard-blocked by
+the upstream's typo.
+
+The standard YAML format goes through a derived deserializer that
+silently drops unknown fields. Typos in standard-format configuration
+parse as if the unknown key were absent (so `if-exits: preserve`
+produces no warning and `if_exists` falls back to its default
+`Overwrite`).
+
 ### `exclude` - Remove Files
 
 Remove files from the in-memory filesystem based on glob patterns.

--- a/docs/src/schema.md
+++ b/docs/src/schema.md
@@ -96,7 +96,9 @@ install-with: [apt-get, brew, platform]
 upstream:
   - url: https://github.com/shakefu/commonrepo
     ref: v1.1.0
-    overwrite: false  # TBD if this should be implemented
+    # The v1 `overwrite: false` note is implemented in v2 as the
+    # `if-exists:` field on `include:` operators. See the v2
+    # Configuration Reference for details.
     include: [.*]
     exclude: [.gitignore]
     rename: [{".*\\.md": "docs/$1"}]

--- a/docs/src/schema.md
+++ b/docs/src/schema.md
@@ -98,7 +98,7 @@ upstream:
     ref: v1.1.0
     # The v1 `overwrite: false` note is implemented in v2 as the
     # `if-exists:` field on `include:` operators. See the v2
-    # Configuration Reference for details.
+    # [Configuration Reference](configuration.md#include---add-files) for details.
     include: [.*]
     exclude: [.gitignore]
     rename: [{".*\\.md": "docs/$1"}]

--- a/src/commands/info.rs
+++ b/src/commands/info.rs
@@ -245,7 +245,7 @@ struct OperationCounts {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use common_repo::config::{ExcludeOp, IncludeOp, Operation, RepoOp};
+    use common_repo::config::{ExcludeOp, IfExists, IncludeOp, Operation, RepoOp};
     use std::path::PathBuf;
     use tempfile::TempDir;
 
@@ -263,6 +263,7 @@ mod tests {
             Operation::Include {
                 include: IncludeOp {
                     patterns: vec!["*.rs".to_string()],
+                    if_exists: IfExists::Overwrite,
                 },
             },
             Operation::Exclude {
@@ -273,6 +274,7 @@ mod tests {
             Operation::Include {
                 include: IncludeOp {
                     patterns: vec!["*.md".to_string()],
+                    if_exists: IfExists::Overwrite,
                 },
             },
         ];

--- a/src/commands/info.rs
+++ b/src/commands/info.rs
@@ -265,6 +265,7 @@ mod tests {
                     patterns: vec!["*.rs".to_string()],
                     if_exists: IfExists::Overwrite,
                 },
+                if_exists: IfExists::Overwrite,
             },
             Operation::Exclude {
                 exclude: ExcludeOp {
@@ -276,6 +277,7 @@ mod tests {
                     patterns: vec!["*.md".to_string()],
                     if_exists: IfExists::Overwrite,
                 },
+                if_exists: IfExists::Overwrite,
             },
         ];
 

--- a/src/commands/validate.rs
+++ b/src/commands/validate.rs
@@ -187,7 +187,7 @@ pub fn execute(args: ValidateArgs, color_flag: &str) -> Result<()> {
                     }
                 }
             }
-            config::Operation::Include { include } => {
+            config::Operation::Include { include, .. } => {
                 // Validate glob patterns
                 for pattern in &include.patterns {
                     if let Err(e) = glob::Pattern::new(pattern) {

--- a/src/config.rs
+++ b/src/config.rs
@@ -1368,9 +1368,16 @@ fn warn_unknown_siblings(op_type: &str, siblings: &serde_yaml::Mapping, recogniz
     for (key, _) in siblings {
         if let Some(key_str) = key.as_str() {
             if !recognized.contains(&key_str) {
+                // Sanitize control characters (newlines, ANSI escapes, etc.)
+                // so that a malicious or malformed YAML key cannot inject fake
+                // log lines or corrupt terminal output.
+                let key_display: String = key_str
+                    .chars()
+                    .map(|c| if c.is_control() { '\u{FFFD}' } else { c })
+                    .collect();
                 log::warn!(
                     "unknown key '{}' in {} operation, ignoring",
-                    key_str,
+                    key_display,
                     op_type
                 );
             }
@@ -3956,6 +3963,38 @@ mod tests {
             assert!(
                 warnings[0].body.contains("include"),
                 "warning body: {}",
+                warnings[0].body
+            );
+        });
+    }
+
+    #[test]
+    fn convert_yaml_mapping_warns_on_unknown_sibling_with_newline() {
+        // A YAML key containing a newline must not appear literally in the log
+        // message — the sanitizer should replace it with U+FFFD.
+        testing_logger::setup();
+        // Construct a YAML mapping directly so the key can contain a literal
+        // newline without going through the YAML parser's string escaping.
+        let mut siblings = serde_yaml::Mapping::new();
+        siblings.insert(
+            serde_yaml::Value::String("if-exits\nFAKE".to_string()),
+            serde_yaml::Value::String("preserve".to_string()),
+        );
+        warn_unknown_siblings("include", &siblings, &["if-exists"]);
+        testing_logger::validate(|captured_logs| {
+            let warnings: Vec<_> = captured_logs
+                .iter()
+                .filter(|l| l.level == log::Level::Warn)
+                .collect();
+            assert_eq!(warnings.len(), 1, "expected one warning");
+            assert!(
+                !warnings[0].body.contains('\n'),
+                "warning body must not contain a literal newline: {:?}",
+                warnings[0].body
+            );
+            assert!(
+                warnings[0].body.contains('\u{FFFD}'),
+                "warning body should contain replacement character: {:?}",
                 warnings[0].body
             );
         });

--- a/src/config.rs
+++ b/src/config.rs
@@ -3988,4 +3988,58 @@ mod tests {
             );
         });
     }
+
+    #[test]
+    fn convert_yaml_mapping_include_rejects_non_string_if_exists() {
+        let yaml = r#"
+- include: ["src/**"]
+  if-exists: 42
+"#;
+        let result = parse_original_format(yaml);
+        assert!(
+            result.is_err(),
+            "non-string if-exists value should error: got {:?}",
+            result
+        );
+    }
+
+    #[test]
+    fn standard_format_silently_drops_unknown_sibling() {
+        testing_logger::setup();
+        let yaml = r#"
+- include: ["src/**"]
+  if-exits: preserve
+"#;
+        // Standard format goes through serde's derived path which silently
+        // drops unknown fields. Parsing succeeds with default if_exists.
+        let schema = parse(yaml).unwrap();
+        match &schema[0] {
+            Operation::Include { include, if_exists } => {
+                assert_eq!(
+                    *if_exists,
+                    IfExists::Overwrite,
+                    "default if_exists after serde-drop of typo key"
+                );
+                assert_eq!(
+                    include.if_exists,
+                    IfExists::Overwrite,
+                    "include.if_exists should also be default after normalize"
+                );
+            }
+            _ => panic!("expected Include"),
+        }
+        testing_logger::validate(|logs| {
+            let warns: Vec<_> = logs
+                .iter()
+                .filter(|l| l.level == log::Level::Warn)
+                .collect();
+            // Standard format does NOT warn — that's the documented behavior.
+            assert_eq!(
+                warns.len(),
+                0,
+                "standard format silently drops unknown siblings, no warning expected; got {:?}",
+                warns.iter().map(|l| &l.body).collect::<Vec<_>>()
+            );
+        });
+    }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -1322,19 +1322,18 @@ pub fn parse_original_format(yaml_content: &str) -> Result<Schema> {
     Ok(operations)
 }
 
-/// Convert a YAML mapping to an Operation (handles original format)
 /// Extracts the `if-exists:` value from the operator-level sibling
 /// mapping. Returns `IfExists::Overwrite` (the default) when the key is
 /// absent. A malformed value (e.g. `if-exists: garbage`) is a parse
 /// error.
 fn extract_if_exists_sibling(siblings: &serde_yaml::Mapping) -> Result<IfExists> {
-    let key = serde_yaml::Value::String("if-exists".to_string());
-    match siblings.get(&key) {
+    match siblings.get("if-exists") {
         Some(value) => serde_yaml::from_value(value.clone()).map_err(Error::Yaml),
         None => Ok(IfExists::Overwrite),
     }
 }
 
+/// Convert a YAML mapping to an Operation (handles original format)
 fn convert_yaml_mapping_to_operation(map: serde_yaml::Mapping) -> Result<Operation> {
     let mut iter = map.into_iter();
     let (key, value) = iter.next().ok_or_else(|| Error::ConfigParse {
@@ -3776,10 +3775,12 @@ mod tests {
   if-exists: overwrite
 "#;
         let schema = parse_original_format(yaml).unwrap();
-        if let Operation::Include { if_exists, .. } = &schema[0] {
-            assert_eq!(*if_exists, IfExists::Overwrite);
-        } else {
-            panic!("expected Operation::Include");
+        match &schema[0] {
+            Operation::Include { include, if_exists } => {
+                assert_eq!(*if_exists, IfExists::Overwrite);
+                assert_eq!(include.if_exists, IfExists::Overwrite);
+            }
+            _ => panic!("expected Operation::Include"),
         }
     }
 
@@ -3790,10 +3791,12 @@ mod tests {
   if-exists: error
 "#;
         let schema = parse_original_format(yaml).unwrap();
-        if let Operation::Include { if_exists, .. } = &schema[0] {
-            assert_eq!(*if_exists, IfExists::Error);
-        } else {
-            panic!("expected Operation::Include");
+        match &schema[0] {
+            Operation::Include { include, if_exists } => {
+                assert_eq!(*if_exists, IfExists::Error);
+                assert_eq!(include.if_exists, IfExists::Error);
+            }
+            _ => panic!("expected Operation::Include"),
         }
     }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -1053,7 +1053,16 @@ pub enum Operation {
     /// configurations.
     Repo { repo: RepoOp },
     /// Include a set of files in the final output.
-    Include { include: IncludeOp },
+    ///
+    /// `if_exists` is captured at the variant level for the standard YAML
+    /// format (`include: [...]` with `if-exists:` as a sibling key); a
+    /// post-parse normalize step copies it into `IncludeOp.if_exists`,
+    /// which is the canonical location consumers read from.
+    Include {
+        include: IncludeOp,
+        #[serde(default, rename = "if-exists")]
+        if_exists: IfExists,
+    },
     /// Exclude a set of files from the final output.
     Exclude { exclude: ExcludeOp },
     /// Mark a set of files as templates to be processed for variable
@@ -1396,6 +1405,7 @@ fn convert_yaml_mapping_to_operation(map: serde_yaml::Mapping) -> Result<Operati
             let patterns: Vec<String> = serde_yaml::from_value(value).map_err(Error::Yaml)?;
             Ok(Operation::Include {
                 include: IncludeOp { patterns, if_exists: IfExists::Overwrite },
+                if_exists: IfExists::Overwrite,
             })
         }
         "exclude" => {
@@ -1582,7 +1592,7 @@ mod tests {
         }
 
         match &schema[1] {
-            Operation::Include { include } => {
+            Operation::Include { include, .. } => {
                 assert_eq!(include.patterns, vec!["**/*", "*.md"]);
             }
             _ => panic!("Expected Include operation"),
@@ -1736,7 +1746,7 @@ mod tests {
         }
 
         match &schema[1] {
-            Operation::Include { include } => {
+            Operation::Include { include, .. } => {
                 assert_eq!(include.patterns, vec!["**/*.md", "docs/**"]);
             }
             _ => panic!("Expected Include operation"),
@@ -1837,7 +1847,7 @@ mod tests {
         let schema = parse(include_yaml).expect("Failed to parse include example from schema.yaml");
         assert_eq!(schema.len(), 1);
         match &schema[0] {
-            Operation::Include { include } => {
+            Operation::Include { include, .. } => {
                 assert_eq!(include.patterns, vec!["**/*", ".*/**/*", ".gitignore"]);
             }
             _ => panic!("Expected Include operation"),
@@ -2081,7 +2091,7 @@ mod tests {
 
                 // Check include in with clause (original format)
                 match &repo.with[0] {
-                    Operation::Include { include } => {
+                    Operation::Include { include, .. } => {
                         assert_eq!(include.patterns, vec![".*"]);
                     }
                     _ => panic!("Expected Include operation"),
@@ -2120,7 +2130,7 @@ mod tests {
 
         // Check include operation (original format)
         match &schema[1] {
-            Operation::Include { include } => {
+            Operation::Include { include, .. } => {
                 assert_eq!(include.patterns, vec!["src/**", "tests/**"]);
             }
             _ => panic!("Expected Include operation"),
@@ -3028,6 +3038,7 @@ mod tests {
                     patterns: vec!["*.rs".to_string()],
                     if_exists: IfExists::Overwrite,
                 },
+                if_exists: IfExists::Overwrite,
             };
             assert!(!op.is_deferred());
         }
@@ -3436,6 +3447,7 @@ mod tests {
                         patterns: vec!["src/**".to_string()],
                         if_exists: IfExists::Overwrite,
                     },
+                    if_exists: IfExists::Overwrite,
                 },
             ];
             let upstream_deferred_ops: Vec<Operation> = vec![];
@@ -3686,5 +3698,40 @@ mod tests {
             vec!["src/**".to_string(), "*.md".to_string()]
         );
         assert_eq!(parsed.if_exists, IfExists::Overwrite); // because Serialize never emitted if_exists
+    }
+
+    #[test]
+    fn operation_include_variant_captures_if_exists_sibling() {
+        let yaml = r#"
+- include: ["src/**"]
+  if-exists: preserve
+"#;
+        let schema: Schema = serde_yaml::from_str(yaml).unwrap();
+        match &schema[0] {
+            Operation::Include { if_exists, .. } => {
+                assert_eq!(*if_exists, IfExists::Preserve);
+            }
+            _ => panic!("expected Operation::Include"),
+        }
+    }
+
+    // Cross-task test: full normalize lands in Task 5. Until then, the variant
+    // captures the sibling but `IncludeOp.if_exists` stays Overwrite.
+    #[ignore = "blocked on Task 5 normalize: variant captures sibling, IncludeOp does not yet"]
+    #[test]
+    fn operation_include_parses_with_if_exists_sibling_standard_format() {
+        let yaml = r#"
+- include: ["src/**"]
+  if-exists: preserve
+"#;
+        let schema: Schema = parse(yaml).unwrap();
+        assert_eq!(schema.len(), 1);
+        match &schema[0] {
+            Operation::Include { include, .. } => {
+                assert_eq!(include.patterns, vec!["src/**".to_string()]);
+                assert_eq!(include.if_exists, IfExists::Preserve);
+            }
+            _ => panic!("expected Operation::Include"),
+        }
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -3671,4 +3671,20 @@ mod tests {
         assert_eq!(op.patterns, vec!["src/**".to_string(), "*.md".to_string()]);
         assert_eq!(op.if_exists, IfExists::Overwrite);
     }
+
+    #[test]
+    fn include_op_serializes_to_bare_list() {
+        let op = IncludeOp {
+            patterns: vec!["src/**".to_string(), "*.md".to_string()],
+            if_exists: IfExists::Preserve, // intentionally non-default to prove if_exists is NOT serialized
+        };
+        let yaml = serde_yaml::to_string(&op).unwrap();
+        // Round-trip: parse it back and confirm we get a bare list (and if_exists drops back to Overwrite default)
+        let parsed: IncludeOp = serde_yaml::from_str(&yaml).unwrap();
+        assert_eq!(
+            parsed.patterns,
+            vec!["src/**".to_string(), "*.md".to_string()]
+        );
+        assert_eq!(parsed.if_exists, IfExists::Overwrite); // because Serialize never emitted if_exists
+    }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -187,6 +187,25 @@ pub enum InsertPosition {
     End,
 }
 
+/// Behavior when an `include`-tagged file's destination already exists
+/// in the consumer's working tree at write time.
+///
+/// `Overwrite` is the default and matches pre-`if-exists:` behavior:
+/// the include result clobbers any local content at the destination.
+/// `Preserve` skips the write so consumer-authored content survives.
+/// `Error` fails the propagation with a clear message naming the path.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "lowercase")]
+pub enum IfExists {
+    /// Overwrite the destination (default, matches pre-feature behavior).
+    #[default]
+    Overwrite,
+    /// Skip the write when the destination exists in the local working tree.
+    Preserve,
+    /// Fail propagation when the destination exists in the local working tree.
+    Error,
+}
+
 /// YAML merge operator configuration
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
 pub struct YamlMergeOp {
@@ -3568,5 +3587,35 @@ mod tests {
             },
         }];
         assert!(validate_repo_ref(&schema).is_ok());
+    }
+
+    #[test]
+    fn if_exists_default_is_overwrite() {
+        let value: IfExists = Default::default();
+        assert_eq!(value, IfExists::Overwrite);
+    }
+
+    #[test]
+    fn if_exists_deserializes_overwrite_lowercase() {
+        let parsed: IfExists = serde_yaml::from_str("overwrite").unwrap();
+        assert_eq!(parsed, IfExists::Overwrite);
+    }
+
+    #[test]
+    fn if_exists_deserializes_preserve_lowercase() {
+        let parsed: IfExists = serde_yaml::from_str("preserve").unwrap();
+        assert_eq!(parsed, IfExists::Preserve);
+    }
+
+    #[test]
+    fn if_exists_deserializes_error_lowercase() {
+        let parsed: IfExists = serde_yaml::from_str("error").unwrap();
+        assert_eq!(parsed, IfExists::Error);
+    }
+
+    #[test]
+    fn if_exists_rejects_invalid_value() {
+        let result: std::result::Result<IfExists, _> = serde_yaml::from_str("garbage");
+        assert!(result.is_err());
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -1365,7 +1365,7 @@ fn extract_if_exists_sibling(siblings: &serde_yaml::Mapping) -> Result<IfExists>
 /// inner-struct fields (e.g. `RepoOp.url`) are not currently subject to
 /// this warning.
 fn warn_unknown_siblings(op_type: &str, siblings: &serde_yaml::Mapping, recognized: &[&str]) {
-    for (key, _) in siblings.iter() {
+    for (key, _) in siblings {
         if let Some(key_str) = key.as_str() {
             if !recognized.contains(&key_str) {
                 log::warn!(

--- a/src/config.rs
+++ b/src/config.rs
@@ -108,12 +108,15 @@ impl RepoOp {
 ///     - "*.md"
 /// ```
 ///
-/// The `if_exists` field is populated at the operator-dispatch level
-/// (either via the `Operation::Include` variant's `if-exists:` sibling
-/// in the standard format, or directly by `convert_yaml_mapping_to_operation`
-/// in the original format). It is not deserialized from this struct's
-/// wire form, which remains a bare list of patterns for backward
-/// compatibility.
+/// The `if_exists` field is populated at the operator-dispatch level —
+/// presently via the `Operation::Include` variant's `if-exists:` sibling
+/// in the standard format. The original-format parser
+/// (`convert_yaml_mapping_to_operation`) currently always emits
+/// `Overwrite`; a follow-up will extend it to read the sibling key, and a
+/// post-parse normalize step will copy the variant value into this field
+/// so all downstream code reads from one canonical location. The field is
+/// not deserialized from this struct's wire form, which remains a bare
+/// list of patterns for backward compatibility.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct IncludeOp {
     /// A list of glob patterns specifying the files to include.

--- a/src/config.rs
+++ b/src/config.rs
@@ -1217,6 +1217,32 @@ pub fn check_merge_provenance(
 /// The operations are executed in the order they are defined in the file.
 pub type Schema = Vec<Operation>;
 
+/// After deserialization, copy each `Operation::Include` variant's
+/// `if_exists` into its inner `IncludeOp.if_exists`. Recurses into
+/// `Operation::Repo`'s `with:` clauses and `Operation::Self_`'s
+/// inner operations.
+///
+/// The variant field is the wire-format capture point (it sees the
+/// sibling key in standard-format YAML); the inner `IncludeOp.if_exists`
+/// is the canonical location every downstream consumer (`include::apply`,
+/// `filter_if_exists`, etc.) reads from.
+fn normalize_include_if_exists(schema: &mut Schema) {
+    for op in schema.iter_mut() {
+        match op {
+            Operation::Include { include, if_exists } => {
+                include.if_exists = *if_exists;
+            }
+            Operation::Repo { repo } => {
+                normalize_include_if_exists(&mut repo.with);
+            }
+            Operation::Self_ { self_ } => {
+                normalize_include_if_exists(&mut self_.operations);
+            }
+            _ => {}
+        }
+    }
+}
+
 /// Parses a YAML string into a `Schema`.
 ///
 /// This function supports both the current, more structured format and the
@@ -1225,13 +1251,14 @@ pub type Schema = Vec<Operation>;
 /// to the original format parser.
 pub fn parse(yaml_content: &str) -> Result<Schema> {
     // First try parsing as the current format
-    let schema = match serde_yaml::from_str::<Schema>(yaml_content) {
+    let mut schema = match serde_yaml::from_str::<Schema>(yaml_content) {
         Ok(schema) => schema,
         Err(_) => {
             // If that fails, try parsing as the original user-friendly format
             parse_original_format(yaml_content)?
         }
     };
+    normalize_include_if_exists(&mut schema);
     validate_self_operations(&schema)?;
     validate_repo_ref(&schema)?;
     Ok(schema)
@@ -3800,9 +3827,7 @@ mod tests {
         }
     }
 
-    // Cross-task test: full normalize lands in Task 5. Until then, the variant
-    // captures the sibling but `IncludeOp.if_exists` stays Overwrite.
-    #[ignore = "blocked on Task 5 normalize: variant captures sibling, IncludeOp does not yet"]
+    // Cross-task test: full normalize lands in Task 5.
     #[test]
     fn operation_include_parses_with_if_exists_sibling_standard_format() {
         let yaml = r#"
@@ -3817,6 +3842,49 @@ mod tests {
                 assert_eq!(include.if_exists, IfExists::Preserve);
             }
             _ => panic!("expected Operation::Include"),
+        }
+    }
+
+    #[test]
+    fn normalize_recurses_into_repo_with() {
+        let yaml = r#"
+- repo:
+    url: https://example.com/foo
+    ref: main
+    with:
+      - include: ["**"]
+        if-exists: preserve
+"#;
+        let schema = parse(yaml).unwrap();
+        if let Operation::Repo { repo } = &schema[0] {
+            if let Operation::Include { include, if_exists } = &repo.with[0] {
+                assert_eq!(*if_exists, IfExists::Preserve);
+                assert_eq!(include.if_exists, IfExists::Preserve);
+            } else {
+                panic!("expected Include in with");
+            }
+        } else {
+            panic!("expected Repo");
+        }
+    }
+
+    #[test]
+    fn normalize_recurses_into_self_block() {
+        let yaml = r#"
+- self:
+  - include: ["*.bak"]
+    if-exists: preserve
+"#;
+        let schema = parse(yaml).unwrap();
+        if let Operation::Self_ { self_ } = &schema[0] {
+            if let Operation::Include { include, if_exists } = &self_.operations[0] {
+                assert_eq!(*if_exists, IfExists::Preserve);
+                assert_eq!(include.if_exists, IfExists::Preserve);
+            } else {
+                panic!("expected Include in self");
+            }
+        } else {
+            panic!("expected Self_");
         }
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -108,15 +108,14 @@ impl RepoOp {
 ///     - "*.md"
 /// ```
 ///
-/// The `if_exists` field is populated at the operator-dispatch level —
-/// presently via the `Operation::Include` variant's `if-exists:` sibling
-/// in the standard format. The original-format parser
-/// (`convert_yaml_mapping_to_operation`) currently always emits
-/// `Overwrite`; a follow-up will extend it to read the sibling key, and a
-/// post-parse normalize step will copy the variant value into this field
-/// so all downstream code reads from one canonical location. The field is
-/// not deserialized from this struct's wire form, which remains a bare
-/// list of patterns for backward compatibility.
+/// The `if_exists` field is the canonical location for downstream
+/// consumers. After [`parse`], it always reflects the correct value: the
+/// original-format parser (`convert_yaml_mapping_to_operation`) writes it
+/// directly, and the standard-format path writes it via the post-parse
+/// `normalize_include_if_exists` step that copies from the
+/// `Operation::Include` variant's `if_exists` field. The field is not
+/// deserialized from this struct's wire form, which remains a bare list
+/// of patterns for backward compatibility.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct IncludeOp {
     /// A list of glob patterns specifying the files to include.

--- a/src/config.rs
+++ b/src/config.rs
@@ -1323,6 +1323,18 @@ pub fn parse_original_format(yaml_content: &str) -> Result<Schema> {
 }
 
 /// Convert a YAML mapping to an Operation (handles original format)
+/// Extracts the `if-exists:` value from the operator-level sibling
+/// mapping. Returns `IfExists::Overwrite` (the default) when the key is
+/// absent. A malformed value (e.g. `if-exists: garbage`) is a parse
+/// error.
+fn extract_if_exists_sibling(siblings: &serde_yaml::Mapping) -> Result<IfExists> {
+    let key = serde_yaml::Value::String("if-exists".to_string());
+    match siblings.get(&key) {
+        Some(value) => serde_yaml::from_value(value.clone()).map_err(Error::Yaml),
+        None => Ok(IfExists::Overwrite),
+    }
+}
+
 fn convert_yaml_mapping_to_operation(map: serde_yaml::Mapping) -> Result<Operation> {
     let mut iter = map.into_iter();
     let (key, value) = iter.next().ok_or_else(|| Error::ConfigParse {
@@ -1330,12 +1342,20 @@ fn convert_yaml_mapping_to_operation(map: serde_yaml::Mapping) -> Result<Operati
         hint: None,
     })?;
 
-    let op_type = key.as_str().ok_or_else(|| Error::ConfigParse {
-        message: "Operation key must be string".to_string(),
-        hint: None,
-    })?;
+    let op_type = key
+        .as_str()
+        .ok_or_else(|| Error::ConfigParse {
+            message: "Operation key must be string".to_string(),
+            hint: None,
+        })?
+        .to_string();
 
-    match op_type {
+    // Collect remaining sibling keys so individual op arms can read them
+    // (e.g. `if-exists:` on `include:`) and so unknown siblings can be
+    // warned on (see Task 6).
+    let siblings: serde_yaml::Mapping = iter.collect();
+
+    match op_type.as_str() {
         "repo" => {
             // Special handling for repo operations since they may contain 'with' operations
             // that are also in the original format
@@ -1406,9 +1426,13 @@ fn convert_yaml_mapping_to_operation(map: serde_yaml::Mapping) -> Result<Operati
         }
         "include" => {
             let patterns: Vec<String> = serde_yaml::from_value(value).map_err(Error::Yaml)?;
+            let if_exists = extract_if_exists_sibling(&siblings)?;
             Ok(Operation::Include {
-                include: IncludeOp { patterns, if_exists: IfExists::Overwrite },
-                if_exists: IfExists::Overwrite,
+                include: IncludeOp {
+                    patterns,
+                    if_exists,
+                },
+                if_exists,
             })
         }
         "exclude" => {
@@ -3715,6 +3739,61 @@ mod tests {
                 assert_eq!(*if_exists, IfExists::Preserve);
             }
             _ => panic!("expected Operation::Include"),
+        }
+    }
+
+    #[test]
+    fn convert_yaml_mapping_include_reads_if_exists_sibling() {
+        let yaml = r#"
+- include: ["src/**"]
+  if-exists: preserve
+"#;
+        let schema = parse_original_format(yaml).unwrap();
+        match &schema[0] {
+            Operation::Include { include, if_exists } => {
+                assert_eq!(include.patterns, vec!["src/**".to_string()]);
+                assert_eq!(*if_exists, IfExists::Preserve);
+                assert_eq!(include.if_exists, IfExists::Preserve);
+            }
+            _ => panic!("expected Operation::Include"),
+        }
+    }
+
+    #[test]
+    fn convert_yaml_mapping_include_rejects_invalid_if_exists() {
+        let yaml = r#"
+- include: ["src/**"]
+  if-exists: garbage
+"#;
+        let result = parse_original_format(yaml);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn convert_yaml_mapping_include_reads_if_exists_overwrite() {
+        let yaml = r#"
+- include: ["src/**"]
+  if-exists: overwrite
+"#;
+        let schema = parse_original_format(yaml).unwrap();
+        if let Operation::Include { if_exists, .. } = &schema[0] {
+            assert_eq!(*if_exists, IfExists::Overwrite);
+        } else {
+            panic!("expected Operation::Include");
+        }
+    }
+
+    #[test]
+    fn convert_yaml_mapping_include_reads_if_exists_error() {
+        let yaml = r#"
+- include: ["src/**"]
+  if-exists: error
+"#;
+        let schema = parse_original_format(yaml).unwrap();
+        if let Operation::Include { if_exists, .. } = &schema[0] {
+            assert_eq!(*if_exists, IfExists::Error);
+        } else {
+            panic!("expected Operation::Include");
         }
     }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -1400,7 +1400,7 @@ fn convert_yaml_mapping_to_operation(map: serde_yaml::Mapping) -> Result<Operati
 
     match op_type.as_str() {
         "repo" => {
-            warn_unknown_siblings("repo", &siblings, &[]);
+            warn_unknown_siblings(&op_type, &siblings, &[]);
             // Special handling for repo operations since they may contain 'with' operations
             // that are also in the original format
             let mut repo_map = match value {
@@ -1469,7 +1469,7 @@ fn convert_yaml_mapping_to_operation(map: serde_yaml::Mapping) -> Result<Operati
             })
         }
         "include" => {
-            warn_unknown_siblings("include", &siblings, &["if-exists"]);
+            warn_unknown_siblings(&op_type, &siblings, &["if-exists"]);
             let patterns: Vec<String> = serde_yaml::from_value(value).map_err(Error::Yaml)?;
             let if_exists = extract_if_exists_sibling(&siblings)?;
             Ok(Operation::Include {
@@ -1481,21 +1481,21 @@ fn convert_yaml_mapping_to_operation(map: serde_yaml::Mapping) -> Result<Operati
             })
         }
         "exclude" => {
-            warn_unknown_siblings("exclude", &siblings, &[]);
+            warn_unknown_siblings(&op_type, &siblings, &[]);
             let patterns: Vec<String> = serde_yaml::from_value(value).map_err(Error::Yaml)?;
             Ok(Operation::Exclude {
                 exclude: ExcludeOp { patterns },
             })
         }
         "template" => {
-            warn_unknown_siblings("template", &siblings, &[]);
+            warn_unknown_siblings(&op_type, &siblings, &[]);
             let patterns: Vec<String> = serde_yaml::from_value(value).map_err(Error::Yaml)?;
             Ok(Operation::Template {
                 template: TemplateOp { patterns },
             })
         }
         "rename" => {
-            warn_unknown_siblings("rename", &siblings, &[]);
+            warn_unknown_siblings(&op_type, &siblings, &[]);
             // Try parsing as the current format first (Vec<RenameMapping>)
             match serde_yaml::from_value::<Vec<RenameMapping>>(value.clone()) {
                 Ok(mappings) => Ok(Operation::Rename {
@@ -1526,7 +1526,7 @@ fn convert_yaml_mapping_to_operation(map: serde_yaml::Mapping) -> Result<Operati
             }
         }
         "tools" => {
-            warn_unknown_siblings("tools", &siblings, &[]);
+            warn_unknown_siblings(&op_type, &siblings, &[]);
             // Try parsing as the current format first (Vec<Tool>)
             match serde_yaml::from_value::<Vec<Tool>>(value.clone()) {
                 Ok(tools) => Ok(Operation::Tools {
@@ -1558,7 +1558,7 @@ fn convert_yaml_mapping_to_operation(map: serde_yaml::Mapping) -> Result<Operati
             }
         }
         "template-vars" => {
-            warn_unknown_siblings("template-vars", &siblings, &[]);
+            warn_unknown_siblings(&op_type, &siblings, &[]);
             // Try parsing as the current format first (TemplateVars with vars field)
             match serde_yaml::from_value::<TemplateVars>(value.clone()) {
                 Ok(template_vars) => Ok(Operation::TemplateVars { template_vars }),
@@ -1574,37 +1574,37 @@ fn convert_yaml_mapping_to_operation(map: serde_yaml::Mapping) -> Result<Operati
             }
         }
         "yaml" => {
-            warn_unknown_siblings("yaml", &siblings, &[]);
+            warn_unknown_siblings(&op_type, &siblings, &[]);
             let yaml: YamlMergeOp = serde_yaml::from_value(value).map_err(Error::Yaml)?;
             Ok(Operation::Yaml { yaml })
         }
         "json" => {
-            warn_unknown_siblings("json", &siblings, &[]);
+            warn_unknown_siblings(&op_type, &siblings, &[]);
             let json: JsonMergeOp = serde_yaml::from_value(value).map_err(Error::Yaml)?;
             Ok(Operation::Json { json })
         }
         "toml" => {
-            warn_unknown_siblings("toml", &siblings, &[]);
+            warn_unknown_siblings(&op_type, &siblings, &[]);
             let toml: TomlMergeOp = serde_yaml::from_value(value).map_err(Error::Yaml)?;
             Ok(Operation::Toml { toml })
         }
         "ini" => {
-            warn_unknown_siblings("ini", &siblings, &[]);
+            warn_unknown_siblings(&op_type, &siblings, &[]);
             let ini: IniMergeOp = serde_yaml::from_value(value).map_err(Error::Yaml)?;
             Ok(Operation::Ini { ini })
         }
         "markdown" => {
-            warn_unknown_siblings("markdown", &siblings, &[]);
+            warn_unknown_siblings(&op_type, &siblings, &[]);
             let markdown: MarkdownMergeOp = serde_yaml::from_value(value).map_err(Error::Yaml)?;
             Ok(Operation::Markdown { markdown })
         }
         "xml" => {
-            warn_unknown_siblings("xml", &siblings, &[]);
+            warn_unknown_siblings(&op_type, &siblings, &[]);
             let xml: XmlMergeOp = serde_yaml::from_value(value).map_err(Error::Yaml)?;
             Ok(Operation::Xml { xml })
         }
         "self" => {
-            warn_unknown_siblings("self", &siblings, &[]);
+            warn_unknown_siblings(&op_type, &siblings, &[]);
             // Self operations contain a sub-list of operations
             match value {
                 serde_yaml::Value::Sequence(seq) => {

--- a/src/config.rs
+++ b/src/config.rs
@@ -1353,10 +1353,11 @@ pub fn parse_original_format(yaml_content: &str) -> Result<Schema> {
 /// absent. A malformed value (e.g. `if-exists: garbage`) is a parse
 /// error.
 fn extract_if_exists_sibling(siblings: &serde_yaml::Mapping) -> Result<IfExists> {
-    match siblings.get("if-exists") {
-        Some(value) => serde_yaml::from_value(value.clone()).map_err(Error::Yaml),
-        None => Ok(IfExists::Overwrite),
-    }
+    siblings
+        .get("if-exists")
+        .map_or(Ok(IfExists::Overwrite), |value| {
+            serde_yaml::from_value(value.clone()).map_err(Error::Yaml)
+        })
 }
 
 /// Emit [`log::warn!`] for any keys in `siblings` that are not in the

--- a/src/config.rs
+++ b/src/config.rs
@@ -1359,6 +1359,24 @@ fn extract_if_exists_sibling(siblings: &serde_yaml::Mapping) -> Result<IfExists>
     }
 }
 
+/// Emit [`log::warn!`] for any keys in `siblings` that are not in the
+/// allow-list `recognized`. Used at the operator-dispatch layer only —
+/// inner-struct fields (e.g. `RepoOp.url`) are not currently subject to
+/// this warning.
+fn warn_unknown_siblings(op_type: &str, siblings: &serde_yaml::Mapping, recognized: &[&str]) {
+    for (key, _) in siblings.iter() {
+        if let Some(key_str) = key.as_str() {
+            if !recognized.contains(&key_str) {
+                log::warn!(
+                    "unknown key '{}' in {} operation, ignoring",
+                    key_str,
+                    op_type
+                );
+            }
+        }
+    }
+}
+
 /// Convert a YAML mapping to an Operation (handles original format)
 fn convert_yaml_mapping_to_operation(map: serde_yaml::Mapping) -> Result<Operation> {
     let mut iter = map.into_iter();
@@ -1382,6 +1400,7 @@ fn convert_yaml_mapping_to_operation(map: serde_yaml::Mapping) -> Result<Operati
 
     match op_type.as_str() {
         "repo" => {
+            warn_unknown_siblings("repo", &siblings, &[]);
             // Special handling for repo operations since they may contain 'with' operations
             // that are also in the original format
             let mut repo_map = match value {
@@ -1450,6 +1469,7 @@ fn convert_yaml_mapping_to_operation(map: serde_yaml::Mapping) -> Result<Operati
             })
         }
         "include" => {
+            warn_unknown_siblings("include", &siblings, &["if-exists"]);
             let patterns: Vec<String> = serde_yaml::from_value(value).map_err(Error::Yaml)?;
             let if_exists = extract_if_exists_sibling(&siblings)?;
             Ok(Operation::Include {
@@ -1461,18 +1481,21 @@ fn convert_yaml_mapping_to_operation(map: serde_yaml::Mapping) -> Result<Operati
             })
         }
         "exclude" => {
+            warn_unknown_siblings("exclude", &siblings, &[]);
             let patterns: Vec<String> = serde_yaml::from_value(value).map_err(Error::Yaml)?;
             Ok(Operation::Exclude {
                 exclude: ExcludeOp { patterns },
             })
         }
         "template" => {
+            warn_unknown_siblings("template", &siblings, &[]);
             let patterns: Vec<String> = serde_yaml::from_value(value).map_err(Error::Yaml)?;
             Ok(Operation::Template {
                 template: TemplateOp { patterns },
             })
         }
         "rename" => {
+            warn_unknown_siblings("rename", &siblings, &[]);
             // Try parsing as the current format first (Vec<RenameMapping>)
             match serde_yaml::from_value::<Vec<RenameMapping>>(value.clone()) {
                 Ok(mappings) => Ok(Operation::Rename {
@@ -1503,6 +1526,7 @@ fn convert_yaml_mapping_to_operation(map: serde_yaml::Mapping) -> Result<Operati
             }
         }
         "tools" => {
+            warn_unknown_siblings("tools", &siblings, &[]);
             // Try parsing as the current format first (Vec<Tool>)
             match serde_yaml::from_value::<Vec<Tool>>(value.clone()) {
                 Ok(tools) => Ok(Operation::Tools {
@@ -1534,6 +1558,7 @@ fn convert_yaml_mapping_to_operation(map: serde_yaml::Mapping) -> Result<Operati
             }
         }
         "template-vars" => {
+            warn_unknown_siblings("template-vars", &siblings, &[]);
             // Try parsing as the current format first (TemplateVars with vars field)
             match serde_yaml::from_value::<TemplateVars>(value.clone()) {
                 Ok(template_vars) => Ok(Operation::TemplateVars { template_vars }),
@@ -1549,30 +1574,37 @@ fn convert_yaml_mapping_to_operation(map: serde_yaml::Mapping) -> Result<Operati
             }
         }
         "yaml" => {
+            warn_unknown_siblings("yaml", &siblings, &[]);
             let yaml: YamlMergeOp = serde_yaml::from_value(value).map_err(Error::Yaml)?;
             Ok(Operation::Yaml { yaml })
         }
         "json" => {
+            warn_unknown_siblings("json", &siblings, &[]);
             let json: JsonMergeOp = serde_yaml::from_value(value).map_err(Error::Yaml)?;
             Ok(Operation::Json { json })
         }
         "toml" => {
+            warn_unknown_siblings("toml", &siblings, &[]);
             let toml: TomlMergeOp = serde_yaml::from_value(value).map_err(Error::Yaml)?;
             Ok(Operation::Toml { toml })
         }
         "ini" => {
+            warn_unknown_siblings("ini", &siblings, &[]);
             let ini: IniMergeOp = serde_yaml::from_value(value).map_err(Error::Yaml)?;
             Ok(Operation::Ini { ini })
         }
         "markdown" => {
+            warn_unknown_siblings("markdown", &siblings, &[]);
             let markdown: MarkdownMergeOp = serde_yaml::from_value(value).map_err(Error::Yaml)?;
             Ok(Operation::Markdown { markdown })
         }
         "xml" => {
+            warn_unknown_siblings("xml", &siblings, &[]);
             let xml: XmlMergeOp = serde_yaml::from_value(value).map_err(Error::Yaml)?;
             Ok(Operation::Xml { xml })
         }
         "self" => {
+            warn_unknown_siblings("self", &siblings, &[]);
             // Self operations contain a sub-list of operations
             match value {
                 serde_yaml::Value::Sequence(seq) => {
@@ -3885,5 +3917,75 @@ mod tests {
         } else {
             panic!("expected Self_");
         }
+    }
+
+    #[test]
+    fn convert_yaml_mapping_include_warns_on_unknown_sibling() {
+        testing_logger::setup();
+        let yaml = r#"
+- include: ["src/**"]
+  if-exits: preserve
+"#;
+        // Parse succeeds — warning is non-fatal.
+        let schema = parse_original_format(yaml).unwrap();
+        match &schema[0] {
+            Operation::Include { include, if_exists } => {
+                assert_eq!(include.patterns, vec!["src/**".to_string()]);
+                assert_eq!(*if_exists, IfExists::Overwrite);
+                assert_eq!(include.if_exists, IfExists::Overwrite);
+            }
+            _ => panic!("expected Operation::Include"),
+        }
+        testing_logger::validate(|captured_logs| {
+            let warnings: Vec<_> = captured_logs
+                .iter()
+                .filter(|l| l.level == log::Level::Warn)
+                .collect();
+            assert_eq!(
+                warnings.len(),
+                1,
+                "expected exactly one warning, got {} warnings",
+                warnings.len()
+            );
+            assert!(
+                warnings[0].body.contains("if-exits"),
+                "warning body: {}",
+                warnings[0].body
+            );
+            assert!(
+                warnings[0].body.contains("include"),
+                "warning body: {}",
+                warnings[0].body
+            );
+        });
+    }
+
+    #[test]
+    fn convert_yaml_mapping_repo_warns_on_operator_level_if_exists() {
+        testing_logger::setup();
+        let yaml = r#"
+- repo:
+    url: https://example.com/foo
+    ref: main
+  if-exists: preserve
+"#;
+        // Parse succeeds — warning is non-fatal.
+        // (`if-exists:` on a repo operator at the operator level is
+        // unrecognized; spec decision #2 keeps the field on `IncludeOp` only.)
+        let schema = parse_original_format(yaml).unwrap();
+        assert!(matches!(&schema[0], Operation::Repo { .. }));
+        testing_logger::validate(|captured_logs| {
+            let warnings: Vec<_> = captured_logs
+                .iter()
+                .filter(|l| l.level == log::Level::Warn)
+                .collect();
+            assert!(
+                warnings
+                    .iter()
+                    .any(|w| w.body.contains("if-exists") && w.body.contains("repo")),
+                "expected warning about 'if-exists' on 'repo'; got {} warnings",
+                warnings.len()
+            );
+        });
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -101,17 +101,47 @@ impl RepoOp {
 
 /// Include operator configuration
 ///
-/// Deserializes directly from a list of patterns:
+/// Deserializes from a list of patterns:
 /// ```yaml
 /// - include:
 ///     - "**/*"
 ///     - "*.md"
 /// ```
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(transparent)]
+///
+/// The `if_exists` field is populated at the operator-dispatch level
+/// (either via the `Operation::Include` variant's `if-exists:` sibling
+/// in the standard format, or directly by `convert_yaml_mapping_to_operation`
+/// in the original format). It is not deserialized from this struct's
+/// wire form, which remains a bare list of patterns for backward
+/// compatibility.
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct IncludeOp {
     /// A list of glob patterns specifying the files to include.
     pub patterns: Vec<String>,
+    /// Behavior when the destination of an included file exists locally.
+    pub if_exists: IfExists,
+}
+
+impl<'de> serde::Deserialize<'de> for IncludeOp {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let patterns: Vec<String> = Vec::deserialize(deserializer)?;
+        Ok(IncludeOp {
+            patterns,
+            if_exists: IfExists::Overwrite,
+        })
+    }
+}
+
+impl serde::Serialize for IncludeOp {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        self.patterns.serialize(serializer)
+    }
 }
 
 /// Exclude operator configuration
@@ -1365,7 +1395,7 @@ fn convert_yaml_mapping_to_operation(map: serde_yaml::Mapping) -> Result<Operati
         "include" => {
             let patterns: Vec<String> = serde_yaml::from_value(value).map_err(Error::Yaml)?;
             Ok(Operation::Include {
-                include: IncludeOp { patterns },
+                include: IncludeOp { patterns, if_exists: IfExists::Overwrite },
             })
         }
         "exclude" => {
@@ -2996,6 +3026,7 @@ mod tests {
             let op = Operation::Include {
                 include: IncludeOp {
                     patterns: vec!["*.rs".to_string()],
+                    if_exists: IfExists::Overwrite,
                 },
             };
             assert!(!op.is_deferred());
@@ -3403,6 +3434,7 @@ mod tests {
                 Operation::Include {
                     include: IncludeOp {
                         patterns: vec!["src/**".to_string()],
+                        if_exists: IfExists::Overwrite,
                     },
                 },
             ];
@@ -3617,5 +3649,26 @@ mod tests {
     fn if_exists_rejects_invalid_value() {
         let result: std::result::Result<IfExists, _> = serde_yaml::from_str("garbage");
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn include_op_default_if_exists_is_overwrite() {
+        let op = IncludeOp {
+            patterns: vec!["src/**".to_string()],
+            if_exists: IfExists::Overwrite,
+        };
+        assert_eq!(op.if_exists, IfExists::Overwrite);
+        assert_eq!(op.patterns, vec!["src/**".to_string()]);
+    }
+
+    #[test]
+    fn include_op_parses_bare_list_form() {
+        let yaml = r#"
+- "src/**"
+- "*.md"
+"#;
+        let op: IncludeOp = serde_yaml::from_str(yaml).unwrap();
+        assert_eq!(op.patterns, vec!["src/**".to_string(), "*.md".to_string()]);
+        assert_eq!(op.if_exists, IfExists::Overwrite);
     }
 }

--- a/src/filesystem.rs
+++ b/src/filesystem.rs
@@ -48,6 +48,11 @@ pub struct File {
     pub modified_time: SystemTime,
     /// A flag indicating whether this file should be processed as a template.
     pub is_template: bool,
+    /// Behavior when this file's destination already exists in the
+    /// consumer's working tree at write time. Set at `include::apply`
+    /// time; flows passively through every other operator. The
+    /// `filter_if_exists` pass at the tail of the pipeline acts on it.
+    pub if_exists: crate::config::IfExists,
 }
 
 impl File {
@@ -74,6 +79,7 @@ impl File {
             permissions: 0o644, // Default to standard file permissions
             modified_time: SystemTime::now(),
             is_template: false,
+            if_exists: crate::config::IfExists::Overwrite,
         }
     }
 
@@ -791,5 +797,23 @@ mod tests {
         let source = fs.get_file("source.txt").unwrap();
         let copy = fs.get_file("nested/path/copy.txt").unwrap();
         assert_eq!(source.content, copy.content);
+    }
+}
+
+#[cfg(test)]
+mod if_exists_tests {
+    use super::*;
+    use crate::config::IfExists;
+
+    #[test]
+    fn file_new_defaults_if_exists_to_overwrite() {
+        let file = File::new(vec![1, 2, 3]);
+        assert_eq!(file.if_exists, IfExists::Overwrite);
+    }
+
+    #[test]
+    fn file_from_string_defaults_if_exists_to_overwrite() {
+        let file = File::from_string("hello");
+        assert_eq!(file.if_exists, IfExists::Overwrite);
     }
 }

--- a/src/filesystem.rs
+++ b/src/filesystem.rs
@@ -31,6 +31,7 @@
 //! pipeline, as it allows each phase to operate on a consistent and isolated
 //! view of the filesystem.
 
+use crate::config::IfExists;
 use crate::error::{Error, Result};
 use glob::Pattern;
 use std::collections::HashMap;
@@ -52,7 +53,7 @@ pub struct File {
     /// consumer's working tree at write time. Set at `include::apply`
     /// time; flows passively through every other operator. The
     /// `filter_if_exists` pass at the tail of the pipeline acts on it.
-    pub if_exists: crate::config::IfExists,
+    pub if_exists: IfExists,
 }
 
 impl File {
@@ -79,7 +80,7 @@ impl File {
             permissions: 0o644, // Default to standard file permissions
             modified_time: SystemTime::now(),
             is_template: false,
-            if_exists: crate::config::IfExists::Overwrite,
+            if_exists: IfExists::Overwrite,
         }
     }
 
@@ -803,7 +804,6 @@ mod tests {
 #[cfg(test)]
 mod if_exists_tests {
     use super::*;
-    use crate::config::IfExists;
 
     #[test]
     fn file_new_defaults_if_exists_to_overwrite() {

--- a/src/git.rs
+++ b/src/git.rs
@@ -236,6 +236,7 @@ fn add_file(
             .modified()
             .unwrap_or(std::time::SystemTime::UNIX_EPOCH),
         is_template: false,
+        if_exists: crate::config::IfExists::Overwrite,
     };
     fs.add_file(dest, file)?;
     Ok(())

--- a/src/operators.rs
+++ b/src/operators.rs
@@ -196,7 +196,7 @@ pub(crate) mod repo {
     pub(crate) fn apply_with_clause(operations: &[Operation], fs: &mut MemoryFS) -> Result<()> {
         for operation in operations {
             match operation {
-                Operation::Include { include } => {
+                Operation::Include { include, .. } => {
                     // In a `with:` clause, include filters the filesystem to keep only
                     // files that match the patterns. This is different from the regular
                     // include operator which copies files from source to target.
@@ -749,6 +749,7 @@ mod tests {
                     patterns: vec!["src/*.rs".to_string()],
                     if_exists: IfExists::Overwrite,
                 },
+                if_exists: IfExists::Overwrite,
             }];
 
             repo::apply_with_clause(&operations, &mut fs).unwrap();
@@ -1092,6 +1093,7 @@ mod tests {
                     patterns: vec!["src/*.rs".to_string(), "tests/*.rs".to_string()],
                     if_exists: IfExists::Overwrite,
                 },
+                if_exists: IfExists::Overwrite,
             }];
 
             repo::apply_with_clause(&operations, &mut fs).unwrap();
@@ -1121,6 +1123,7 @@ mod tests {
                         patterns: vec!["src/*".to_string(), "template.txt".to_string()],
                         if_exists: IfExists::Overwrite,
                     },
+                    if_exists: IfExists::Overwrite,
                 },
                 // Then rename src/ to rust/
                 Operation::Rename {
@@ -1166,6 +1169,7 @@ mod tests {
                     patterns: vec!["*.rs".to_string()],
                     if_exists: IfExists::Overwrite,
                 },
+                if_exists: IfExists::Overwrite,
             }];
 
             repo::apply_with_clause(&operations, &mut fs).unwrap();
@@ -1187,6 +1191,7 @@ mod tests {
                     patterns: vec!["**/*".to_string()],
                     if_exists: IfExists::Overwrite,
                 },
+                if_exists: IfExists::Overwrite,
             }];
 
             repo::apply_with_clause(&operations, &mut fs).unwrap();

--- a/src/operators.rs
+++ b/src/operators.rs
@@ -58,8 +58,9 @@ pub(crate) mod include {
 
             for path in matching_files {
                 if let Some(file) = source.get_file(&path) {
-                    // Clone the file to add to target
-                    target.add_file(&path, file.clone())?;
+                    let mut file = file.clone();
+                    file.if_exists = op.if_exists;
+                    target.add_file(&path, file)?;
                 }
             }
         }
@@ -325,6 +326,65 @@ mod tests {
             assert!(target.exists("src/main.rs"));
             assert!(!target.exists("tests/test.rs"));
             assert!(target.exists("README.md"));
+        }
+    }
+
+    mod include_apply_tests {
+        use super::*;
+        use crate::config::{IfExists, IncludeOp};
+        use crate::filesystem::{File, MemoryFS};
+
+        #[test]
+        fn include_apply_default_overwrite_tags_files() {
+            let mut source = MemoryFS::new();
+            source
+                .add_file("foo.txt", File::from_string("hello"))
+                .unwrap();
+            let op = IncludeOp {
+                patterns: vec!["foo.txt".to_string()],
+                if_exists: IfExists::Overwrite,
+            };
+            let mut target = MemoryFS::new();
+            include::apply(&op, &source, &mut target).unwrap();
+            let file = target.get_file("foo.txt").unwrap();
+            assert_eq!(file.if_exists, IfExists::Overwrite);
+        }
+
+        #[test]
+        fn include_apply_preserve_tags_files() {
+            let mut source = MemoryFS::new();
+            source
+                .add_file("foo.txt", File::from_string("hello"))
+                .unwrap();
+            let op = IncludeOp {
+                patterns: vec!["foo.txt".to_string()],
+                if_exists: IfExists::Preserve,
+            };
+            let mut target = MemoryFS::new();
+            include::apply(&op, &source, &mut target).unwrap();
+            let file = target.get_file("foo.txt").unwrap();
+            assert_eq!(file.if_exists, IfExists::Preserve);
+        }
+
+        #[test]
+        fn include_apply_last_op_wins_on_same_path() {
+            let mut source = MemoryFS::new();
+            source
+                .add_file("foo.txt", File::from_string("hello"))
+                .unwrap();
+            let op_first = IncludeOp {
+                patterns: vec!["foo.txt".to_string()],
+                if_exists: IfExists::Preserve,
+            };
+            let op_second = IncludeOp {
+                patterns: vec!["foo.txt".to_string()],
+                if_exists: IfExists::Overwrite,
+            };
+            let mut target = MemoryFS::new();
+            include::apply(&op_first, &source, &mut target).unwrap();
+            include::apply(&op_second, &source, &mut target).unwrap();
+            let file = target.get_file("foo.txt").unwrap();
+            assert_eq!(file.if_exists, IfExists::Overwrite);
         }
     }
 

--- a/src/operators.rs
+++ b/src/operators.rs
@@ -269,7 +269,7 @@ pub(crate) mod repo {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::config::{RenameMapping, RenameOp};
+    use crate::config::{IfExists, RenameMapping, RenameOp};
 
     mod include_tests {
         use super::*;
@@ -291,6 +291,7 @@ mod tests {
             // Include all .rs files
             let op = IncludeOp {
                 patterns: vec!["*.rs".to_string()],
+                if_exists: IfExists::Overwrite,
             };
 
             include::apply(&op, &source, &mut target).unwrap();
@@ -316,6 +317,7 @@ mod tests {
 
             let op = IncludeOp {
                 patterns: vec!["src/*.rs".to_string(), "README.md".to_string()],
+                if_exists: IfExists::Overwrite,
             };
 
             include::apply(&op, &source, &mut target).unwrap();
@@ -745,6 +747,7 @@ mod tests {
             let operations = vec![Operation::Include {
                 include: IncludeOp {
                     patterns: vec!["src/*.rs".to_string()],
+                    if_exists: IfExists::Overwrite,
                 },
             }];
 
@@ -1087,6 +1090,7 @@ mod tests {
             let operations = vec![Operation::Include {
                 include: IncludeOp {
                     patterns: vec!["src/*.rs".to_string(), "tests/*.rs".to_string()],
+                    if_exists: IfExists::Overwrite,
                 },
             }];
 
@@ -1115,6 +1119,7 @@ mod tests {
                 Operation::Include {
                     include: IncludeOp {
                         patterns: vec!["src/*".to_string(), "template.txt".to_string()],
+                        if_exists: IfExists::Overwrite,
                     },
                 },
                 // Then rename src/ to rust/
@@ -1159,6 +1164,7 @@ mod tests {
             let operations = vec![Operation::Include {
                 include: IncludeOp {
                     patterns: vec!["*.rs".to_string()],
+                    if_exists: IfExists::Overwrite,
                 },
             }];
 
@@ -1179,6 +1185,7 @@ mod tests {
             let operations = vec![Operation::Include {
                 include: IncludeOp {
                     patterns: vec!["**/*".to_string()],
+                    if_exists: IfExists::Overwrite,
                 },
             }];
 

--- a/src/operators.rs
+++ b/src/operators.rs
@@ -44,6 +44,13 @@ pub(crate) mod include {
     /// copies files from the source to the target if they match the glob patterns
     /// defined in the `IncludeOp`.
     ///
+    /// Each copied file has its `if_exists` field set to `op.if_exists`,
+    /// overwriting any default on the source file. If the same path is matched
+    /// by multiple `include` operations, the last one wins because
+    /// `MemoryFS::add_file` unconditionally replaces any prior entry — so the
+    /// final tag at any path is the tag from the last `include::apply` call
+    /// that produced it.
+    ///
     /// # Arguments
     ///
     /// * `op` - The include operation configuration

--- a/src/operators.rs
+++ b/src/operators.rs
@@ -585,6 +585,66 @@ mod tests {
         }
     }
 
+    mod tag_propagation_tests {
+        use super::*;
+        use crate::config::{IfExists, RenameMapping, RenameOp};
+        use crate::filesystem::{File, MemoryFS};
+
+        #[test]
+        fn rename_apply_preserves_if_exists_tag() {
+            let mut fs = MemoryFS::new();
+            let mut file = File::from_string("hello");
+            file.if_exists = IfExists::Preserve;
+            fs.add_file("foo.bak", file).unwrap();
+
+            let op = RenameOp {
+                mappings: vec![RenameMapping {
+                    from: r"^(.+)\.bak$".to_string(),
+                    to: "$1".to_string(),
+                }],
+            };
+            rename::apply(&op, &mut fs).unwrap();
+
+            let renamed = fs.get_file("foo").unwrap();
+            assert_eq!(
+                renamed.if_exists,
+                IfExists::Preserve,
+                "rename should preserve if_exists tag"
+            );
+            assert!(
+                fs.get_file("foo.bak").is_none(),
+                "old name should be gone after rename"
+            );
+        }
+
+        #[test]
+        fn exclude_apply_preserves_if_exists_tag_on_remaining_files() {
+            let mut fs = MemoryFS::new();
+            let mut keep = File::from_string("keep");
+            keep.if_exists = IfExists::Preserve;
+            fs.add_file("keep.txt", keep).unwrap();
+            let mut drop_file = File::from_string("drop");
+            drop_file.if_exists = IfExists::Error;
+            fs.add_file("drop.txt", drop_file).unwrap();
+
+            let op = ExcludeOp {
+                patterns: vec!["drop.txt".to_string()],
+            };
+            exclude::apply(&op, &mut fs).unwrap();
+
+            assert!(
+                fs.get_file("drop.txt").is_none(),
+                "excluded file should be removed"
+            );
+            let kept = fs.get_file("keep.txt").unwrap();
+            assert_eq!(
+                kept.if_exists,
+                IfExists::Preserve,
+                "exclude should not modify surviving files' if_exists tags"
+            );
+        }
+    }
+
     mod repo_tests {
         use super::*;
         use crate::config::{ExcludeOp, IncludeOp, RenameMapping};
@@ -1883,6 +1943,51 @@ mod template_tests {
 
         template_vars::collect(&op, &mut context).unwrap();
         assert_eq!(context.len(), 4);
+    }
+
+    #[test]
+    fn template_mark_preserves_if_exists_tag() {
+        let mut fs = MemoryFS::new();
+        let mut file = crate::filesystem::File::from_string("hello __COMMON_REPO__NAME__");
+        file.if_exists = crate::config::IfExists::Preserve;
+        fs.add_file("greet.txt", file).unwrap();
+
+        let op = crate::config::TemplateOp {
+            patterns: vec!["greet.txt".to_string()],
+        };
+        template::mark(&op, &mut fs).unwrap();
+
+        let marked = fs.get_file("greet.txt").unwrap();
+        assert_eq!(
+            marked.if_exists,
+            crate::config::IfExists::Preserve,
+            "template::mark should preserve if_exists tag"
+        );
+        assert!(marked.is_template, "file should be marked as a template");
+    }
+
+    #[test]
+    fn template_process_preserves_if_exists_tag_through_expansion() {
+        let mut fs = MemoryFS::new();
+        let mut file = crate::filesystem::File::from_string("hello __COMMON_REPO__NAME__");
+        file.if_exists = crate::config::IfExists::Preserve;
+        file.is_template = true;
+        fs.add_file("greet.txt", file).unwrap();
+
+        let mut vars = HashMap::new();
+        vars.insert("NAME".to_string(), "world".to_string());
+        template::process(&mut fs, &vars).unwrap();
+
+        let processed = fs.get_file("greet.txt").unwrap();
+        assert_eq!(
+            processed.if_exists,
+            crate::config::IfExists::Preserve,
+            "template::process should preserve if_exists tag"
+        );
+        assert_eq!(
+            processed.content, b"hello world",
+            "template should expand variables"
+        );
     }
 }
 

--- a/src/phases/composite.rs
+++ b/src/phases/composite.rs
@@ -882,8 +882,8 @@ port = 8080
     mod execute_merge_operation_tests {
         use super::*;
         use crate::config::{
-            ExcludeOp, IncludeOp, InsertPosition, MarkdownMergeOp, Operation, TomlMergeOp,
-            YamlMergeOp,
+            ExcludeOp, IfExists, IncludeOp, InsertPosition, MarkdownMergeOp, Operation,
+            TomlMergeOp, YamlMergeOp,
         };
         use crate::phases::composite::execute_merge_operation;
 
@@ -984,6 +984,7 @@ port = 8080
             let operation = Operation::Include {
                 include: IncludeOp {
                     patterns: vec!["**/*".to_string()],
+                    if_exists: IfExists::Overwrite,
                 },
             };
 

--- a/src/phases/composite.rs
+++ b/src/phases/composite.rs
@@ -986,6 +986,7 @@ port = 8080
                     patterns: vec!["**/*".to_string()],
                     if_exists: IfExists::Overwrite,
                 },
+                if_exists: IfExists::Overwrite,
             };
 
             let result = execute_merge_operation(&mut fs, &operation);

--- a/src/phases/discovery.rs
+++ b/src/phases/discovery.rs
@@ -606,6 +606,7 @@ mod tests {
                     patterns: vec!["*.rs".to_string()],
                     if_exists: IfExists::Overwrite,
                 },
+                if_exists: IfExists::Overwrite,
             },
             Operation::Exclude {
                 exclude: ExcludeOp {
@@ -653,6 +654,7 @@ mod tests {
                     patterns: vec!["*.rs".to_string()],
                     if_exists: IfExists::Overwrite,
                 },
+                if_exists: IfExists::Overwrite,
             },
             Operation::Repo {
                 repo: RepoOp {
@@ -1191,6 +1193,7 @@ mod tests {
                     patterns: vec!["*.rs".to_string()],
                     if_exists: IfExists::Overwrite,
                 },
+                if_exists: IfExists::Overwrite,
             },
             Operation::Exclude {
                 exclude: ExcludeOp {
@@ -1237,6 +1240,7 @@ mod tests {
                         patterns: vec!["*.rs".to_string()],
                         if_exists: IfExists::Overwrite,
                     },
+                    if_exists: IfExists::Overwrite,
                 },
                 Operation::Exclude {
                     exclude: ExcludeOp {
@@ -1264,6 +1268,7 @@ mod tests {
                         patterns: vec!["*.rs".to_string()],
                         if_exists: IfExists::Overwrite,
                     },
+                    if_exists: IfExists::Overwrite,
                 },
                 Operation::Yaml {
                     yaml: YamlMergeOp {
@@ -1299,6 +1304,7 @@ mod tests {
                         patterns: vec!["**/*".to_string()],
                         if_exists: IfExists::Overwrite,
                     },
+                    if_exists: IfExists::Overwrite,
                 },
                 // First deferred op
                 Operation::Yaml {
@@ -1394,6 +1400,7 @@ mod tests {
                         patterns: vec!["*.md".to_string()],
                         if_exists: IfExists::Overwrite,
                     },
+                    if_exists: IfExists::Overwrite,
                 },
                 Operation::Repo {
                     repo: RepoOp {
@@ -1407,7 +1414,7 @@ mod tests {
             let result = extract_upstream_operations(&config);
             assert_eq!(result.len(), 1);
             match &result[0] {
-                Operation::Include { include } => {
+                Operation::Include { include, .. } => {
                     assert_eq!(include.patterns, vec!["*.md".to_string()]);
                 }
                 _ => panic!("Expected Include operation"),
@@ -1459,6 +1466,7 @@ mod tests {
                         patterns: vec!["src/**".to_string()],
                         if_exists: IfExists::Overwrite,
                     },
+                    if_exists: IfExists::Overwrite,
                 },
                 Operation::Exclude {
                     exclude: ExcludeOp {
@@ -1490,6 +1498,7 @@ mod tests {
                         patterns: vec!["first".to_string()],
                         if_exists: IfExists::Overwrite,
                     },
+                    if_exists: IfExists::Overwrite,
                 },
                 Operation::Exclude {
                     exclude: ExcludeOp {
@@ -1501,13 +1510,14 @@ mod tests {
                         patterns: vec!["third".to_string()],
                         if_exists: IfExists::Overwrite,
                     },
+                    if_exists: IfExists::Overwrite,
                 },
             ];
             let result = extract_upstream_operations(&config);
             assert_eq!(result.len(), 3);
             // Verify order is preserved
             match &result[0] {
-                Operation::Include { include } => {
+                Operation::Include { include, .. } => {
                     assert_eq!(include.patterns[0], "first");
                 }
                 _ => panic!("Expected Include"),
@@ -1519,7 +1529,7 @@ mod tests {
                 _ => panic!("Expected Exclude"),
             }
             match &result[2] {
-                Operation::Include { include } => {
+                Operation::Include { include, .. } => {
                     assert_eq!(include.patterns[0], "third");
                 }
                 _ => panic!("Expected Include"),
@@ -1627,6 +1637,7 @@ mod tests {
                         patterns: vec!["src/**".to_string()],
                         if_exists: IfExists::Overwrite,
                     },
+                    if_exists: IfExists::Overwrite,
                 },
                 Operation::Template {
                     template: TemplateOp {
@@ -1680,6 +1691,7 @@ mod tests {
                     patterns: vec!["src/**".to_string()],
                     if_exists: IfExists::Overwrite,
                 },
+                if_exists: IfExists::Overwrite,
             },
             Operation::Self_ {
                 self_: SelfOp {
@@ -1688,6 +1700,7 @@ mod tests {
                             patterns: vec!["**/*".to_string()],
                             if_exists: IfExists::Overwrite,
                         },
+                        if_exists: IfExists::Overwrite,
                     }],
                 },
             },
@@ -1718,6 +1731,7 @@ mod tests {
                             patterns: vec!["**/*".to_string()],
                             if_exists: IfExists::Overwrite,
                         },
+                        if_exists: IfExists::Overwrite,
                     }],
                 },
             },

--- a/src/phases/discovery.rs
+++ b/src/phases/discovery.rs
@@ -452,7 +452,7 @@ pub fn clone_parallel(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::config::{ExcludeOp, IncludeOp, RepoOp};
+    use crate::config::{ExcludeOp, IfExists, IncludeOp, RepoOp};
     use crate::filesystem::MemoryFS;
     use crate::repository::{CacheOperations, GitOperations};
     use std::path::{Path, PathBuf};
@@ -604,6 +604,7 @@ mod tests {
             Operation::Include {
                 include: IncludeOp {
                     patterns: vec!["*.rs".to_string()],
+                    if_exists: IfExists::Overwrite,
                 },
             },
             Operation::Exclude {
@@ -650,6 +651,7 @@ mod tests {
             Operation::Include {
                 include: IncludeOp {
                     patterns: vec!["*.rs".to_string()],
+                    if_exists: IfExists::Overwrite,
                 },
             },
             Operation::Repo {
@@ -1187,6 +1189,7 @@ mod tests {
             Operation::Include {
                 include: IncludeOp {
                     patterns: vec!["*.rs".to_string()],
+                    if_exists: IfExists::Overwrite,
                 },
             },
             Operation::Exclude {
@@ -1215,7 +1218,9 @@ mod tests {
 
     mod extract_deferred_ops_tests {
         use super::*;
-        use crate::config::{ExcludeOp, IncludeOp, MarkdownMergeOp, Operation, YamlMergeOp};
+        use crate::config::{
+            ExcludeOp, IfExists, IncludeOp, MarkdownMergeOp, Operation, YamlMergeOp,
+        };
 
         #[test]
         fn test_extract_deferred_operations_empty_config() {
@@ -1230,6 +1235,7 @@ mod tests {
                 Operation::Include {
                     include: IncludeOp {
                         patterns: vec!["*.rs".to_string()],
+                        if_exists: IfExists::Overwrite,
                     },
                 },
                 Operation::Exclude {
@@ -1256,6 +1262,7 @@ mod tests {
                 Operation::Include {
                     include: IncludeOp {
                         patterns: vec!["*.rs".to_string()],
+                        if_exists: IfExists::Overwrite,
                     },
                 },
                 Operation::Yaml {
@@ -1290,6 +1297,7 @@ mod tests {
                 Operation::Include {
                     include: IncludeOp {
                         patterns: vec!["**/*".to_string()],
+                        if_exists: IfExists::Overwrite,
                     },
                 },
                 // First deferred op
@@ -1384,6 +1392,7 @@ mod tests {
                 Operation::Include {
                     include: IncludeOp {
                         patterns: vec!["*.md".to_string()],
+                        if_exists: IfExists::Overwrite,
                     },
                 },
                 Operation::Repo {
@@ -1448,6 +1457,7 @@ mod tests {
                 Operation::Include {
                     include: IncludeOp {
                         patterns: vec!["src/**".to_string()],
+                        if_exists: IfExists::Overwrite,
                     },
                 },
                 Operation::Exclude {
@@ -1478,6 +1488,7 @@ mod tests {
                 Operation::Include {
                     include: IncludeOp {
                         patterns: vec!["first".to_string()],
+                        if_exists: IfExists::Overwrite,
                     },
                 },
                 Operation::Exclude {
@@ -1488,6 +1499,7 @@ mod tests {
                 Operation::Include {
                     include: IncludeOp {
                         patterns: vec!["third".to_string()],
+                        if_exists: IfExists::Overwrite,
                     },
                 },
             ];
@@ -1613,6 +1625,7 @@ mod tests {
                 Operation::Include {
                     include: IncludeOp {
                         patterns: vec!["src/**".to_string()],
+                        if_exists: IfExists::Overwrite,
                     },
                 },
                 Operation::Template {
@@ -1659,12 +1672,13 @@ mod tests {
 
     #[test]
     fn test_extract_upstream_operations_excludes_self() {
-        use crate::config::{IncludeOp, Operation, SelfOp};
+        use crate::config::{IfExists, IncludeOp, Operation, SelfOp};
 
         let config = vec![
             Operation::Include {
                 include: IncludeOp {
                     patterns: vec!["src/**".to_string()],
+                    if_exists: IfExists::Overwrite,
                 },
             },
             Operation::Self_ {
@@ -1672,6 +1686,7 @@ mod tests {
                     operations: vec![Operation::Include {
                         include: IncludeOp {
                             patterns: vec!["**/*".to_string()],
+                            if_exists: IfExists::Overwrite,
                         },
                     }],
                 },
@@ -1685,7 +1700,7 @@ mod tests {
 
     #[test]
     fn test_process_config_to_node_keeps_self_in_operations() {
-        use crate::config::{IncludeOp, Operation, RepoOp, SelfOp};
+        use crate::config::{IfExists, IncludeOp, Operation, RepoOp, SelfOp};
 
         let config = vec![
             Operation::Repo {
@@ -1701,6 +1716,7 @@ mod tests {
                     operations: vec![Operation::Include {
                         include: IncludeOp {
                             patterns: vec!["**/*".to_string()],
+                            if_exists: IfExists::Overwrite,
                         },
                     }],
                 },

--- a/src/phases/local_merge.rs
+++ b/src/phases/local_merge.rs
@@ -263,7 +263,7 @@ fn apply_consumer_operations(final_fs: &mut MemoryFS, local_config: &Schema) -> 
             Operation::Exclude { exclude } => {
                 operators::exclude::apply(exclude, final_fs)?;
             }
-            Operation::Include { include } => {
+            Operation::Include { include, .. } => {
                 // include::apply copies matching files into a new FS rather than
                 // removing non-matching files, so we replace the entire FS with
                 // the filtered result.
@@ -703,6 +703,7 @@ mod tests {
                 patterns: vec!["*.txt".to_string()],
                 if_exists: IfExists::Overwrite,
             },
+            if_exists: IfExists::Overwrite,
         }];
 
         let final_fs = execute(&composite_fs, &local_config, working_dir, &[]).unwrap();
@@ -894,6 +895,7 @@ mod tests {
                     patterns: vec!["src/**".to_string()],
                     if_exists: IfExists::Overwrite,
                 },
+                if_exists: IfExists::Overwrite,
             },
             // Step 2: Merge fragment into config (both survived the include)
             Operation::Json {

--- a/src/phases/local_merge.rs
+++ b/src/phases/local_merge.rs
@@ -345,9 +345,8 @@ pub(crate) fn filter_if_exists(
     };
     let mut error_paths: Vec<String> = Vec::new();
     for path in paths {
-        let file = match composite.get_file(&path) {
-            Some(f) => f,
-            None => continue,
+        let Some(file) = composite.get_file(&path) else {
+            continue;
         };
         let disk_path = working_dir.join(&path);
         let exists_on_disk = disk_path.symlink_metadata().is_ok();

--- a/src/phases/local_merge.rs
+++ b/src/phases/local_merge.rs
@@ -346,14 +346,10 @@ pub(crate) fn filter_if_exists(
         }
     }
     if let Some(path) = error_path {
-        return Err(crate::error::Error::ConfigParse {
+        return Err(crate::error::Error::Operator {
+            operator: "include".to_string(),
             message: format!(
-                "if-exists: error — destination {} exists locally and the include op requested failure",
-                path
-            ),
-            hint: Some(
-                "Change `if-exists:` to `preserve` or `overwrite`, or remove the local file."
-                    .to_string(),
+                "if-exists: error — destination {path} exists locally and the include op requested failure.\n  hint: Change `if-exists:` to `preserve` or `overwrite`, or remove the local file."
             ),
         });
     }
@@ -453,6 +449,48 @@ mod filter_if_exists_tests {
 
         let file = composite.get_file("a.txt").unwrap();
         assert_eq!(file.content, b"from-composite");
+    }
+
+    #[test]
+    fn filter_emits_debug_log_per_skip() {
+        testing_logger::setup();
+        let mut composite = MemoryFS::new();
+        composite
+            .add_file("a.txt", tagged_file("x", IfExists::Preserve))
+            .unwrap();
+        composite
+            .add_file("b.txt", tagged_file("y", IfExists::Preserve))
+            .unwrap();
+        let mut local = MemoryFS::new();
+        local
+            .add_file("a.txt", File::from_string("local-a"))
+            .unwrap();
+        local
+            .add_file("b.txt", File::from_string("local-b"))
+            .unwrap();
+
+        filter_if_exists(&mut composite, &local).unwrap();
+
+        testing_logger::validate(|logs| {
+            let debug_logs: Vec<_> = logs
+                .iter()
+                .filter(|l| l.level == log::Level::Debug)
+                .collect();
+            assert_eq!(
+                debug_logs.len(),
+                2,
+                "expected 2 debug log lines, got {}",
+                debug_logs.len()
+            );
+            assert!(
+                debug_logs.iter().any(|l| l.body.contains("a.txt")),
+                "expected log mentioning 'a.txt'"
+            );
+            assert!(
+                debug_logs.iter().any(|l| l.body.contains("b.txt")),
+                "expected log mentioning 'b.txt'"
+            );
+        });
     }
 }
 

--- a/src/phases/local_merge.rs
+++ b/src/phases/local_merge.rs
@@ -313,7 +313,6 @@ fn apply_consumer_operations(final_fs: &mut MemoryFS, local_config: &Schema) -> 
 ///
 /// Each removal logs at debug level. Errors propagate up through the
 /// pipeline as a propagation-time failure.
-#[allow(dead_code)]
 pub(crate) fn filter_if_exists(
     composite: &mut MemoryFS,
     local: &MemoryFS,

--- a/src/phases/local_merge.rs
+++ b/src/phases/local_merge.rs
@@ -358,7 +358,10 @@ pub(crate) fn filter_if_exists(
                         "if-exists: preserve — skipping {} (destination exists in working dir)",
                         path.display()
                     );
-                    composite.remove_file(&path)?;
+                    // `get_file` confirmed existence above; `remove_file`
+                    // returns `Result<Option<File>>` but the inner `Result`
+                    // is always `Ok` — the implementation is infallible.
+                    let _ = composite.remove_file(&path);
                 }
             }
             IfExists::Error => {

--- a/src/phases/local_merge.rs
+++ b/src/phases/local_merge.rs
@@ -32,6 +32,13 @@
 //!
 //! This phase produces the final, fully merged `MemoryFS`, which is an exact
 //! representation of what the output directory should look like.
+//!
+//! [`filter_if_exists`] is also part of this module's responsibility: before
+//! Phase 5 combines the composite with local files, it checks each composite
+//! entry's `if_exists` tag against the on-disk working tree. Entries tagged
+//! `preserve` are dropped from the composite when the destination already
+//! exists on disk (as a regular file, directory, or symlink). Entries tagged
+//! `error` cause the pipeline to fail with a list of all conflicting paths.
 
 use std::collections::HashMap;
 use std::path::Path;
@@ -306,37 +313,48 @@ fn apply_consumer_operations(final_fs: &mut MemoryFS, local_config: &Schema) -> 
 ///   no longer carries a write for that path).
 /// - `IfExists::Preserve` and the path is missing locally → leave in
 ///   composite (the included file is the only source for that path).
-/// - `IfExists::Error` and the path exists locally → return an
-///   error naming the path.
+/// - `IfExists::Error` and the path exists locally → return an error
+///   listing all conflicting paths.
 /// - `IfExists::Error` and the path is missing locally → leave in
 ///   composite.
+///
+/// Existence is determined by consulting on-disk metadata via
+/// [`std::fs::symlink_metadata`] against `working_dir`, which detects
+/// regular files, directories, and symlinks (including broken ones).
+/// This is broader than checking `MemoryFS::exists`, which only sees
+/// regular files loaded into the in-memory tree.
 ///
 /// Each removal logs at debug level. Errors propagate up through the
 /// pipeline as a propagation-time failure.
 pub(crate) fn filter_if_exists(
     composite: &mut MemoryFS,
     local: &MemoryFS,
+    working_dir: &Path,
 ) -> crate::error::Result<()> {
     use crate::config::IfExists;
-    // Sort paths so that the `Error` arm reports a deterministic path
-    // (the first-by-sort-order conflicting path) and the per-file debug
-    // log lines for `Preserve` skips appear in stable order regardless
-    // of `MemoryFS`'s internal HashMap iteration order.
+    // Suppress unused-variable warning: `local` is kept for API consistency
+    // and future content-comparison use.
+    let _ = local;
+    // Sort paths so that the `Error` arm reports deterministic output and the
+    // per-file debug log lines for `Preserve` skips appear in stable order
+    // regardless of `MemoryFS`'s internal HashMap iteration order.
     let paths: Vec<std::path::PathBuf> = {
         let mut p = composite.list_files();
         p.sort();
         p
     };
-    let mut error_path: Option<String> = None;
+    let mut error_paths: Vec<String> = Vec::new();
     for path in paths {
         let file = match composite.get_file(&path) {
             Some(f) => f,
             None => continue,
         };
+        let disk_path = working_dir.join(&path);
+        let exists_on_disk = disk_path.symlink_metadata().is_ok();
         match file.if_exists {
             IfExists::Overwrite => {}
             IfExists::Preserve => {
-                if local.exists(&path) {
+                if exists_on_disk {
                     log::debug!(
                         "if-exists: preserve — skipping {} (destination exists in working dir)",
                         path.display()
@@ -345,18 +363,18 @@ pub(crate) fn filter_if_exists(
                 }
             }
             IfExists::Error => {
-                if local.exists(&path) {
-                    error_path = Some(path.to_string_lossy().into_owned());
-                    break;
+                if exists_on_disk {
+                    error_paths.push(path.to_string_lossy().into_owned());
                 }
             }
         }
     }
-    if let Some(path) = error_path {
+    if !error_paths.is_empty() {
+        let path_list = error_paths.join("\n  - ");
         return Err(crate::error::Error::Operator {
             operator: "include".to_string(),
             message: format!(
-                "if-exists: error — destination {path} exists locally and the include op requested failure.\n  hint: Change `if-exists:` to `preserve` or `overwrite`, or remove the local file."
+                "if-exists: error — destinations exist locally and the include op requested failure:\n  - {path_list}\n  hint: Change `if-exists:` to `preserve` or `overwrite`, or remove the local file(s)."
             ),
         });
     }
@@ -377,16 +395,16 @@ mod filter_if_exists_tests {
 
     #[test]
     fn filter_overwrite_is_no_op() {
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::write(tmp.path().join("a.txt"), "from-local").unwrap();
+
         let mut composite = MemoryFS::new();
         composite
             .add_file("a.txt", tagged_file("from-composite", IfExists::Overwrite))
             .unwrap();
-        let mut local = MemoryFS::new();
-        local
-            .add_file("a.txt", File::from_string("from-local"))
-            .unwrap();
+        let local = MemoryFS::new();
 
-        filter_if_exists(&mut composite, &local).unwrap();
+        filter_if_exists(&mut composite, &local, tmp.path()).unwrap();
 
         let file = composite.get_file("a.txt").unwrap();
         assert_eq!(file.content, b"from-composite");
@@ -394,29 +412,31 @@ mod filter_if_exists_tests {
 
     #[test]
     fn filter_preserve_drops_when_local_exists() {
-        let mut composite = MemoryFS::new();
-        composite
-            .add_file("a.txt", tagged_file("from-composite", IfExists::Preserve))
-            .unwrap();
-        let mut local = MemoryFS::new();
-        local
-            .add_file("a.txt", File::from_string("from-local"))
-            .unwrap();
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::write(tmp.path().join("a.txt"), "from-local").unwrap();
 
-        filter_if_exists(&mut composite, &local).unwrap();
-
-        assert!(composite.get_file("a.txt").is_none());
-    }
-
-    #[test]
-    fn filter_preserve_keeps_when_local_missing() {
         let mut composite = MemoryFS::new();
         composite
             .add_file("a.txt", tagged_file("from-composite", IfExists::Preserve))
             .unwrap();
         let local = MemoryFS::new();
 
-        filter_if_exists(&mut composite, &local).unwrap();
+        filter_if_exists(&mut composite, &local, tmp.path()).unwrap();
+
+        assert!(composite.get_file("a.txt").is_none());
+    }
+
+    #[test]
+    fn filter_preserve_keeps_when_local_missing() {
+        let tmp = tempfile::tempdir().unwrap();
+
+        let mut composite = MemoryFS::new();
+        composite
+            .add_file("a.txt", tagged_file("from-composite", IfExists::Preserve))
+            .unwrap();
+        let local = MemoryFS::new();
+
+        filter_if_exists(&mut composite, &local, tmp.path()).unwrap();
 
         let file = composite.get_file("a.txt").unwrap();
         assert_eq!(file.content, b"from-composite");
@@ -424,16 +444,16 @@ mod filter_if_exists_tests {
 
     #[test]
     fn filter_error_returns_error_when_local_exists() {
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::write(tmp.path().join("a.txt"), "from-local").unwrap();
+
         let mut composite = MemoryFS::new();
         composite
             .add_file("a.txt", tagged_file("from-composite", IfExists::Error))
             .unwrap();
-        let mut local = MemoryFS::new();
-        local
-            .add_file("a.txt", File::from_string("from-local"))
-            .unwrap();
+        let local = MemoryFS::new();
 
-        let result = filter_if_exists(&mut composite, &local);
+        let result = filter_if_exists(&mut composite, &local, tmp.path());
 
         let err = result.expect_err("expected an error");
         let msg = format!("{}", err);
@@ -446,13 +466,15 @@ mod filter_if_exists_tests {
 
     #[test]
     fn filter_error_keeps_when_local_missing() {
+        let tmp = tempfile::tempdir().unwrap();
+
         let mut composite = MemoryFS::new();
         composite
             .add_file("a.txt", tagged_file("from-composite", IfExists::Error))
             .unwrap();
         let local = MemoryFS::new();
 
-        filter_if_exists(&mut composite, &local).unwrap();
+        filter_if_exists(&mut composite, &local, tmp.path()).unwrap();
 
         let file = composite.get_file("a.txt").unwrap();
         assert_eq!(file.content, b"from-composite");
@@ -460,6 +482,10 @@ mod filter_if_exists_tests {
 
     #[test]
     fn filter_emits_debug_log_per_skip() {
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::write(tmp.path().join("a.txt"), "local-a").unwrap();
+        std::fs::write(tmp.path().join("b.txt"), "local-b").unwrap();
+
         testing_logger::setup();
         let mut composite = MemoryFS::new();
         composite
@@ -468,15 +494,9 @@ mod filter_if_exists_tests {
         composite
             .add_file("b.txt", tagged_file("y", IfExists::Preserve))
             .unwrap();
-        let mut local = MemoryFS::new();
-        local
-            .add_file("a.txt", File::from_string("local-a"))
-            .unwrap();
-        local
-            .add_file("b.txt", File::from_string("local-b"))
-            .unwrap();
+        let local = MemoryFS::new();
 
-        filter_if_exists(&mut composite, &local).unwrap();
+        filter_if_exists(&mut composite, &local, tmp.path()).unwrap();
 
         testing_logger::validate(|logs| {
             let debug_logs: Vec<_> = logs
@@ -498,6 +518,74 @@ mod filter_if_exists_tests {
                 "expected log mentioning 'b.txt'"
             );
         });
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn filter_preserve_drops_when_local_is_symlink() {
+        use std::os::unix::fs::symlink;
+        let tmp = tempfile::tempdir().unwrap();
+        let target = tmp.path().join("target.txt");
+        std::fs::write(&target, "target-content").unwrap();
+        let link = tmp.path().join("link.txt");
+        symlink(&target, &link).unwrap();
+
+        let mut composite = MemoryFS::new();
+        composite
+            .add_file(
+                "link.txt",
+                tagged_file("from-composite", IfExists::Preserve),
+            )
+            .unwrap();
+        let local = MemoryFS::new(); // empty — symlink not loaded by load_local_fs
+
+        filter_if_exists(&mut composite, &local, tmp.path()).unwrap();
+
+        assert!(
+            composite.get_file("link.txt").is_none(),
+            "Preserve should drop when local is a symlink"
+        );
+    }
+
+    #[test]
+    fn filter_preserve_drops_when_local_is_directory() {
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::create_dir(tmp.path().join("foo")).unwrap();
+
+        let mut composite = MemoryFS::new();
+        composite
+            .add_file("foo", tagged_file("from-composite", IfExists::Preserve))
+            .unwrap();
+        let local = MemoryFS::new();
+
+        filter_if_exists(&mut composite, &local, tmp.path()).unwrap();
+
+        assert!(
+            composite.get_file("foo").is_none(),
+            "Preserve should drop when local is a directory"
+        );
+    }
+
+    #[test]
+    fn filter_error_reports_all_conflicting_paths() {
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::write(tmp.path().join("a.txt"), "a").unwrap();
+        std::fs::write(tmp.path().join("z.txt"), "z").unwrap();
+
+        let mut composite = MemoryFS::new();
+        composite
+            .add_file("a.txt", tagged_file("from-composite", IfExists::Error))
+            .unwrap();
+        composite
+            .add_file("z.txt", tagged_file("from-composite", IfExists::Error))
+            .unwrap();
+        let local = MemoryFS::new();
+
+        let result = filter_if_exists(&mut composite, &local, tmp.path());
+        let err = result.expect_err("expected error");
+        let msg = format!("{}", err);
+        assert!(msg.contains("a.txt"), "should mention a.txt: {msg}");
+        assert!(msg.contains("z.txt"), "should mention z.txt: {msg}");
     }
 }
 

--- a/src/phases/local_merge.rs
+++ b/src/phases/local_merge.rs
@@ -297,6 +297,165 @@ fn apply_consumer_operations(final_fs: &mut MemoryFS, local_config: &Schema) -> 
     Ok(())
 }
 
+/// Reconcile per-file `if_exists` tags on the composite against the
+/// consumer's local working tree.
+///
+/// - `IfExists::Overwrite` → leave the file in the composite (default).
+/// - `IfExists::Preserve` and the path exists locally → remove from
+///   composite (consumer-authored content survives because the composite
+///   no longer carries a write for that path).
+/// - `IfExists::Preserve` and the path is missing locally → leave in
+///   composite (the included file is the only source for that path).
+/// - `IfExists::Error` and the path exists locally → return an
+///   error naming the path.
+/// - `IfExists::Error` and the path is missing locally → leave in
+///   composite.
+///
+/// Each removal logs at debug level. Errors propagate up through the
+/// pipeline as a propagation-time failure.
+#[allow(dead_code)]
+pub(crate) fn filter_if_exists(
+    composite: &mut MemoryFS,
+    local: &MemoryFS,
+) -> crate::error::Result<()> {
+    use crate::config::IfExists;
+    let paths: Vec<std::path::PathBuf> = composite.list_files();
+    let mut error_path: Option<String> = None;
+    for path in paths {
+        let file = match composite.get_file(&path) {
+            Some(f) => f,
+            None => continue,
+        };
+        match file.if_exists {
+            IfExists::Overwrite => {}
+            IfExists::Preserve => {
+                if local.exists(&path) {
+                    log::debug!(
+                        "if-exists: preserve — skipping {} (destination exists in working dir)",
+                        path.display()
+                    );
+                    composite.remove_file(&path)?;
+                }
+            }
+            IfExists::Error => {
+                if local.exists(&path) {
+                    error_path = Some(path.to_string_lossy().into_owned());
+                    break;
+                }
+            }
+        }
+    }
+    if let Some(path) = error_path {
+        return Err(crate::error::Error::ConfigParse {
+            message: format!(
+                "if-exists: error — destination {} exists locally and the include op requested failure",
+                path
+            ),
+            hint: Some(
+                "Change `if-exists:` to `preserve` or `overwrite`, or remove the local file."
+                    .to_string(),
+            ),
+        });
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod filter_if_exists_tests {
+    use super::*;
+    use crate::config::IfExists;
+    use crate::filesystem::{File, MemoryFS};
+
+    fn tagged_file(content: &str, tag: IfExists) -> File {
+        let mut f = File::from_string(content);
+        f.if_exists = tag;
+        f
+    }
+
+    #[test]
+    fn filter_overwrite_is_no_op() {
+        let mut composite = MemoryFS::new();
+        composite
+            .add_file("a.txt", tagged_file("from-composite", IfExists::Overwrite))
+            .unwrap();
+        let mut local = MemoryFS::new();
+        local
+            .add_file("a.txt", File::from_string("from-local"))
+            .unwrap();
+
+        filter_if_exists(&mut composite, &local).unwrap();
+
+        let file = composite.get_file("a.txt").unwrap();
+        assert_eq!(file.content, b"from-composite");
+    }
+
+    #[test]
+    fn filter_preserve_drops_when_local_exists() {
+        let mut composite = MemoryFS::new();
+        composite
+            .add_file("a.txt", tagged_file("from-composite", IfExists::Preserve))
+            .unwrap();
+        let mut local = MemoryFS::new();
+        local
+            .add_file("a.txt", File::from_string("from-local"))
+            .unwrap();
+
+        filter_if_exists(&mut composite, &local).unwrap();
+
+        assert!(composite.get_file("a.txt").is_none());
+    }
+
+    #[test]
+    fn filter_preserve_keeps_when_local_missing() {
+        let mut composite = MemoryFS::new();
+        composite
+            .add_file("a.txt", tagged_file("from-composite", IfExists::Preserve))
+            .unwrap();
+        let local = MemoryFS::new();
+
+        filter_if_exists(&mut composite, &local).unwrap();
+
+        let file = composite.get_file("a.txt").unwrap();
+        assert_eq!(file.content, b"from-composite");
+    }
+
+    #[test]
+    fn filter_error_returns_error_when_local_exists() {
+        let mut composite = MemoryFS::new();
+        composite
+            .add_file("a.txt", tagged_file("from-composite", IfExists::Error))
+            .unwrap();
+        let mut local = MemoryFS::new();
+        local
+            .add_file("a.txt", File::from_string("from-local"))
+            .unwrap();
+
+        let result = filter_if_exists(&mut composite, &local);
+
+        let err = result.expect_err("expected an error");
+        let msg = format!("{}", err);
+        assert!(
+            msg.contains("a.txt"),
+            "error message should name the path: {}",
+            msg
+        );
+    }
+
+    #[test]
+    fn filter_error_keeps_when_local_missing() {
+        let mut composite = MemoryFS::new();
+        composite
+            .add_file("a.txt", tagged_file("from-composite", IfExists::Error))
+            .unwrap();
+        let local = MemoryFS::new();
+
+        filter_if_exists(&mut composite, &local).unwrap();
+
+        let file = composite.get_file("a.txt").unwrap();
+        assert_eq!(file.content, b"from-composite");
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/phases/local_merge.rs
+++ b/src/phases/local_merge.rs
@@ -300,7 +300,7 @@ fn apply_consumer_operations(final_fs: &mut MemoryFS, local_config: &Schema) -> 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::config::{ExcludeOp, IncludeOp, JsonMergeOp, RenameMapping, RenameOp};
+    use crate::config::{ExcludeOp, IfExists, IncludeOp, JsonMergeOp, RenameMapping, RenameOp};
     use tempfile::TempDir;
 
     #[test]
@@ -701,6 +701,7 @@ mod tests {
         let local_config = vec![Operation::Include {
             include: IncludeOp {
                 patterns: vec!["*.txt".to_string()],
+                if_exists: IfExists::Overwrite,
             },
         }];
 
@@ -891,6 +892,7 @@ mod tests {
             Operation::Include {
                 include: IncludeOp {
                     patterns: vec!["src/**".to_string()],
+                    if_exists: IfExists::Overwrite,
                 },
             },
             // Step 2: Merge fragment into config (both survived the include)

--- a/src/phases/local_merge.rs
+++ b/src/phases/local_merge.rs
@@ -318,7 +318,15 @@ pub(crate) fn filter_if_exists(
     local: &MemoryFS,
 ) -> crate::error::Result<()> {
     use crate::config::IfExists;
-    let paths: Vec<std::path::PathBuf> = composite.list_files();
+    // Sort paths so that the `Error` arm reports a deterministic path
+    // (the first-by-sort-order conflicting path) and the per-file debug
+    // log lines for `Preserve` skips appear in stable order regardless
+    // of `MemoryFS`'s internal HashMap iteration order.
+    let paths: Vec<std::path::PathBuf> = {
+        let mut p = composite.list_files();
+        p.sort();
+        p
+    };
     let mut error_path: Option<String> = None;
     for path in paths {
         let file = match composite.get_file(&path) {

--- a/src/phases/orchestrator.rs
+++ b/src/phases/orchestrator.rs
@@ -463,13 +463,51 @@ fn execute_sequential_pipeline(
         }
     }
 
+    // Execute residual deferred merges (dest wasn't in the FS during integration).
+    // These run before the filter pass so merge results carry the default
+    // Overwrite tag and are not inadvertently dropped.
+    for op in &residual_deferred_ops {
+        // Load merge source/dest from disk if not in composite (same
+        // rationale as the sequential-pass merge handling above).
+        for path in [op.merge_effective_source(), op.merge_effective_dest()]
+            .into_iter()
+            .flatten()
+        {
+            if !fs.exists(path) {
+                let disk_path = working_dir.join(path);
+                if disk_path.exists() {
+                    let content = std::fs::read(&disk_path)?;
+                    fs.add_file(path, crate::filesystem::File::new(content))?;
+                }
+            }
+        }
+        phase4::execute_merge_operation(&mut fs, op)?;
+    }
+
+    // Process templates with all collected variables.
+    // Runs before the filter pass so template-expanded files carry the
+    // correct if_exists tag when the filter inspects them.
+    crate::operators::template::process(&mut fs, &all_template_vars)?;
+
+    // Load the local FS once for both the filter pass and the source-mode
+    // overlay below. In self-block mode the source FS already loaded at the
+    // top of this function is the local FS, so reuse it rather than re-reading
+    // from disk.
+    let local_fs_for_filter = match mode {
+        PipelineMode::SourceBlock => phase5::load_local_fs(working_dir)?,
+        PipelineMode::SelfBlock => source_fs.as_ref().cloned().unwrap_or_default(),
+    };
+
+    // Filter pass: drop composite entries whose if_exists tag says to
+    // preserve or error-on-conflict when the local file already exists.
+    phase5::filter_if_exists(&mut fs, &local_fs_for_filter)?;
+
     // Source blocks: Phase 5 — combine composite with local files.
     // Local files that are not in the composite are preserved. Composite
     // files win for shared paths (CompositePrecedence invariant). Auto-merge
     // targets use format-aware merging instead of overwriting.
     if mode == PipelineMode::SourceBlock {
-        let local_fs = phase5::load_local_fs(working_dir)?;
-        let mut combined = local_fs;
+        let mut combined = local_fs_for_filter;
         // Overlay composite on top of local files, with auto-merge awareness
         phase4::merge_composite_with_auto_merge(
             &mut combined,
@@ -502,28 +540,6 @@ fn execute_sequential_pipeline(
 
         fs = combined;
     }
-
-    // Execute residual deferred merges (dest wasn't in the FS during integration)
-    for op in &residual_deferred_ops {
-        // Load merge source/dest from disk if not in composite (same
-        // rationale as the sequential-pass merge handling above).
-        for path in [op.merge_effective_source(), op.merge_effective_dest()]
-            .into_iter()
-            .flatten()
-        {
-            if !fs.exists(path) {
-                let disk_path = working_dir.join(path);
-                if disk_path.exists() {
-                    let content = std::fs::read(&disk_path)?;
-                    fs.add_file(path, crate::filesystem::File::new(content))?;
-                }
-            }
-        }
-        phase4::execute_merge_operation(&mut fs, op)?;
-    }
-
-    // Process templates with all collected variables
-    crate::operators::template::process(&mut fs, &all_template_vars)?;
 
     // Phase 6: Write to disk (if output path provided)
     if let Some(output) = output_path {
@@ -1498,6 +1514,58 @@ mod tests {
         assert_eq!(
             result.template_vars.get("CHILD_VAR").unwrap(),
             "child_value"
+        );
+    }
+
+    #[test]
+    fn execute_sequential_pipeline_self_block_filter_if_exists_preserve() {
+        use crate::cache::RepoCache;
+        use crate::config::{IfExists, IncludeOp, Operation};
+        use crate::repository::RepositoryManager;
+        use std::fs;
+        use tempfile::TempDir;
+
+        let working_dir = TempDir::new().unwrap();
+        let output_dir = TempDir::new().unwrap();
+        let working = working_dir.path();
+        let output = output_dir.path();
+
+        // Local file the consumer wrote — the self-block include copies it
+        // into the composite with if_exists: Preserve. The filter should then
+        // detect that the file exists locally and drop it from the composite,
+        // so Phase 6 writes nothing for a.txt to the output directory.
+        fs::write(working.join("a.txt"), b"local-content").unwrap();
+
+        let config: Vec<Operation> = vec![Operation::Include {
+            include: IncludeOp {
+                patterns: vec!["a.txt".to_string()],
+                if_exists: IfExists::Preserve,
+            },
+            if_exists: IfExists::Preserve,
+        }];
+
+        let repo_manager = RepositoryManager::new(working.to_path_buf());
+        let cache = RepoCache::new();
+
+        // Run the self-block pipeline directly (private fn, accessible via
+        // super::* in this test module).
+        execute_sequential_pipeline(
+            &config,
+            &repo_manager,
+            &cache,
+            working,
+            Some(output),
+            PipelineMode::SelfBlock,
+        )
+        .unwrap();
+
+        // The local working-dir file is intact.
+        assert_eq!(fs::read(working.join("a.txt")).unwrap(), b"local-content");
+        // The filter dropped a.txt from the composite before Phase 6 ran,
+        // so nothing was written to the output directory.
+        assert!(
+            !output.join("a.txt").exists(),
+            "a.txt should not be written when if_exists: Preserve and file exists locally"
         );
     }
 }

--- a/src/phases/orchestrator.rs
+++ b/src/phases/orchestrator.rs
@@ -311,7 +311,7 @@ fn execute_sequential_pipeline(
     // For self blocks this is the local working directory on disk. For
     // source blocks the composite is populated by repo: integrations and
     // there is no separate source FS.
-    let source_fs = match mode {
+    let mut source_fs = match mode {
         PipelineMode::SelfBlock => Some(phase5::load_local_fs(working_dir)?),
         PipelineMode::SourceBlock => None,
     };
@@ -496,8 +496,7 @@ fn execute_sequential_pipeline(
     let local_fs_for_filter = match mode {
         PipelineMode::SourceBlock => phase5::load_local_fs(working_dir)?,
         PipelineMode::SelfBlock => source_fs
-            .as_ref()
-            .cloned()
+            .take()
             .expect("SelfBlock mode always loads source_fs at function entry"),
     };
 

--- a/src/phases/orchestrator.rs
+++ b/src/phases/orchestrator.rs
@@ -337,7 +337,7 @@ fn execute_sequential_pipeline(
     // Sequential pass: walk operations in declaration order
     for operation in config {
         match operation {
-            Operation::Include { include } => {
+            Operation::Include { include, .. } => {
                 if let Some(ref source) = source_fs {
                     // Self block: include is additive — pull matching files
                     // from the read-only source FS into the composite. The
@@ -594,6 +594,7 @@ mod tests {
                     patterns: vec!["src/**".to_string()],
                     if_exists: IfExists::Overwrite,
                 },
+                if_exists: IfExists::Overwrite,
             },
             Operation::Self_ {
                 self_: SelfOp {
@@ -602,6 +603,7 @@ mod tests {
                             patterns: vec!["**/*".to_string()],
                             if_exists: IfExists::Overwrite,
                         },
+                        if_exists: IfExists::Overwrite,
                     }],
                 },
             },
@@ -620,6 +622,7 @@ mod tests {
                 patterns: vec!["**/*".to_string()],
                 if_exists: IfExists::Overwrite,
             },
+            if_exists: IfExists::Overwrite,
         }];
 
         let (self_ops, source_ops) = partition_self_operations(&config);
@@ -734,6 +737,7 @@ mod tests {
                             patterns: vec!["a/**".to_string()],
                             if_exists: IfExists::Overwrite,
                         },
+                        if_exists: IfExists::Overwrite,
                     }],
                 },
             },
@@ -742,6 +746,7 @@ mod tests {
                     patterns: vec!["src/**".to_string()],
                     if_exists: IfExists::Overwrite,
                 },
+                if_exists: IfExists::Overwrite,
             },
             Operation::Self_ {
                 self_: SelfOp {
@@ -750,6 +755,7 @@ mod tests {
                             patterns: vec!["b/**".to_string()],
                             if_exists: IfExists::Overwrite,
                         },
+                        if_exists: IfExists::Overwrite,
                     }],
                 },
             },
@@ -1007,6 +1013,7 @@ mod tests {
                     patterns: vec!["src/**".to_string()],
                     if_exists: IfExists::Overwrite,
                 },
+                if_exists: IfExists::Overwrite,
             }],
         );
 
@@ -1097,6 +1104,7 @@ mod tests {
                         patterns: vec!["src/**".to_string()],
                         if_exists: IfExists::Overwrite,
                     },
+                    if_exists: IfExists::Overwrite,
                 },
                 // Second: repo: integrates child files into the FS
                 Operation::Repo {
@@ -1311,6 +1319,7 @@ mod tests {
                 patterns: vec!["a.txt".to_string()],
                 if_exists: IfExists::Overwrite,
             },
+            if_exists: IfExists::Overwrite,
         }];
 
         let result = execute_sequential_pipeline(
@@ -1334,12 +1343,14 @@ mod tests {
                     patterns: vec!["a.txt".to_string()],
                     if_exists: IfExists::Overwrite,
                 },
+                if_exists: IfExists::Overwrite,
             },
             Operation::Include {
                 include: IncludeOp {
                     patterns: vec!["b.txt".to_string()],
                     if_exists: IfExists::Overwrite,
                 },
+                if_exists: IfExists::Overwrite,
             },
         ];
 
@@ -1391,6 +1402,7 @@ mod tests {
                     patterns: vec!["*".to_string()],
                     if_exists: IfExists::Overwrite,
                 },
+                if_exists: IfExists::Overwrite,
             },
             Operation::Exclude {
                 exclude: crate::config::ExcludeOp {
@@ -1402,6 +1414,7 @@ mod tests {
                     patterns: vec!["a.txt".to_string()],
                     if_exists: IfExists::Overwrite,
                 },
+                if_exists: IfExists::Overwrite,
             },
         ];
 

--- a/src/phases/orchestrator.rs
+++ b/src/phases/orchestrator.rs
@@ -495,7 +495,10 @@ fn execute_sequential_pipeline(
     // from disk.
     let local_fs_for_filter = match mode {
         PipelineMode::SourceBlock => phase5::load_local_fs(working_dir)?,
-        PipelineMode::SelfBlock => source_fs.as_ref().cloned().unwrap_or_default(),
+        PipelineMode::SelfBlock => source_fs
+            .as_ref()
+            .cloned()
+            .expect("SelfBlock mode always loads source_fs at function entry"),
     };
 
     // Filter pass: drop composite entries whose if_exists tag says to

--- a/src/phases/orchestrator.rs
+++ b/src/phases/orchestrator.rs
@@ -503,7 +503,7 @@ fn execute_sequential_pipeline(
 
     // Filter pass: drop composite entries whose if_exists tag says to
     // preserve or error-on-conflict when the local file already exists.
-    phase5::filter_if_exists(&mut fs, &local_fs_for_filter)?;
+    phase5::filter_if_exists(&mut fs, &local_fs_for_filter, working_dir)?;
 
     // Source blocks: Phase 5 — combine composite with local files.
     // Local files that are not in the composite are preserved. Composite

--- a/src/phases/orchestrator.rs
+++ b/src/phases/orchestrator.rs
@@ -582,7 +582,7 @@ pub fn execute_pull(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::config::{IncludeOp, Operation, SelfOp};
+    use crate::config::{IfExists, IncludeOp, Operation, SelfOp};
     use crate::phases::ClonedRepo;
     use std::collections::HashMap;
 
@@ -592,6 +592,7 @@ mod tests {
             Operation::Include {
                 include: IncludeOp {
                     patterns: vec!["src/**".to_string()],
+                    if_exists: IfExists::Overwrite,
                 },
             },
             Operation::Self_ {
@@ -599,6 +600,7 @@ mod tests {
                     operations: vec![Operation::Include {
                         include: IncludeOp {
                             patterns: vec!["**/*".to_string()],
+                            if_exists: IfExists::Overwrite,
                         },
                     }],
                 },
@@ -616,6 +618,7 @@ mod tests {
         let config = vec![Operation::Include {
             include: IncludeOp {
                 patterns: vec!["**/*".to_string()],
+                if_exists: IfExists::Overwrite,
             },
         }];
 
@@ -729,6 +732,7 @@ mod tests {
                     operations: vec![Operation::Include {
                         include: IncludeOp {
                             patterns: vec!["a/**".to_string()],
+                            if_exists: IfExists::Overwrite,
                         },
                     }],
                 },
@@ -736,6 +740,7 @@ mod tests {
             Operation::Include {
                 include: IncludeOp {
                     patterns: vec!["src/**".to_string()],
+                    if_exists: IfExists::Overwrite,
                 },
             },
             Operation::Self_ {
@@ -743,6 +748,7 @@ mod tests {
                     operations: vec![Operation::Include {
                         include: IncludeOp {
                             patterns: vec!["b/**".to_string()],
+                            if_exists: IfExists::Overwrite,
                         },
                     }],
                 },
@@ -999,6 +1005,7 @@ mod tests {
             vec![Operation::Include {
                 include: IncludeOp {
                     patterns: vec!["src/**".to_string()],
+                    if_exists: IfExists::Overwrite,
                 },
             }],
         );
@@ -1088,6 +1095,7 @@ mod tests {
                 Operation::Include {
                     include: IncludeOp {
                         patterns: vec!["src/**".to_string()],
+                        if_exists: IfExists::Overwrite,
                     },
                 },
                 // Second: repo: integrates child files into the FS
@@ -1301,6 +1309,7 @@ mod tests {
         let config: Schema = vec![Operation::Include {
             include: IncludeOp {
                 patterns: vec!["a.txt".to_string()],
+                if_exists: IfExists::Overwrite,
             },
         }];
 
@@ -1323,11 +1332,13 @@ mod tests {
             Operation::Include {
                 include: IncludeOp {
                     patterns: vec!["a.txt".to_string()],
+                    if_exists: IfExists::Overwrite,
                 },
             },
             Operation::Include {
                 include: IncludeOp {
                     patterns: vec!["b.txt".to_string()],
+                    if_exists: IfExists::Overwrite,
                 },
             },
         ];
@@ -1378,6 +1389,7 @@ mod tests {
             Operation::Include {
                 include: IncludeOp {
                     patterns: vec!["*".to_string()],
+                    if_exists: IfExists::Overwrite,
                 },
             },
             Operation::Exclude {
@@ -1388,6 +1400,7 @@ mod tests {
             Operation::Include {
                 include: IncludeOp {
                     patterns: vec!["a.txt".to_string()],
+                    if_exists: IfExists::Overwrite,
                 },
             },
         ];

--- a/src/phases/processing.rs
+++ b/src/phases/processing.rs
@@ -374,7 +374,7 @@ pub(crate) fn apply_operation(fs: &mut MemoryFS, operation: &Operation) -> Resul
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::config::{ExcludeOp, IfExists, Operation, RepoOp, TemplateVars};
+    use crate::config::{ExcludeOp, IfExists, IncludeOp, Operation, RepoOp, TemplateVars};
     use crate::filesystem::MemoryFS;
     use crate::repository::{CacheOperations, GitOperations, RepositoryManager};
     use std::collections::HashMap;
@@ -2701,5 +2701,29 @@ mod tests {
             *self.cached_flag.lock().unwrap() = true;
             Ok(())
         }
+    }
+
+    #[test]
+    fn apply_operation_include_stamps_if_exists_tag() {
+        let mut fs = MemoryFS::new();
+        fs.add_file("foo.txt", crate::filesystem::File::from_string("hello"))
+            .unwrap();
+
+        let op = Operation::Include {
+            include: IncludeOp {
+                patterns: vec!["foo.txt".to_string()],
+                if_exists: IfExists::Preserve,
+            },
+            if_exists: IfExists::Preserve,
+        };
+
+        apply_operation(&mut fs, &op).unwrap();
+
+        let file = fs.get_file("foo.txt").unwrap();
+        assert_eq!(
+            file.if_exists,
+            IfExists::Preserve,
+            "apply_operation should stamp if_exists from the operation onto included files"
+        );
     }
 }

--- a/src/phases/processing.rs
+++ b/src/phases/processing.rs
@@ -374,7 +374,7 @@ pub(crate) fn apply_operation(fs: &mut MemoryFS, operation: &Operation) -> Resul
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::config::{ExcludeOp, Operation, RepoOp, TemplateVars};
+    use crate::config::{ExcludeOp, IfExists, Operation, RepoOp, TemplateVars};
     use crate::filesystem::MemoryFS;
     use crate::repository::{CacheOperations, GitOperations, RepositoryManager};
     use std::collections::HashMap;
@@ -682,6 +682,7 @@ mod tests {
                 with: vec![Operation::Include {
                     include: crate::config::IncludeOp {
                         patterns: vec!["*.md".to_string()],
+                        if_exists: IfExists::Overwrite,
                     },
                 }],
             },
@@ -1139,7 +1140,7 @@ mod tests {
 
     mod cache_key_tests {
         use super::*;
-        use crate::config::{ExcludeOp, IncludeOp, RenameMapping, RenameOp, TemplateOp};
+        use crate::config::{ExcludeOp, IfExists, IncludeOp, RenameMapping, RenameOp, TemplateOp};
         use crate::phases::RepoNode;
 
         #[test]
@@ -1278,6 +1279,7 @@ mod tests {
                 Operation::Include {
                     include: IncludeOp {
                         patterns: vec!["src/**".to_string()],
+                        if_exists: IfExists::Overwrite,
                     },
                 },
                 Operation::Rename {
@@ -1679,9 +1681,9 @@ mod tests {
     mod apply_operation_tests {
         use super::*;
         use crate::config::{
-            ExcludeOp, IncludeOp, IniMergeOp, InsertPosition, JsonMergeOp, MarkdownMergeOp,
-            RenameMapping, RenameOp, TemplateOp, TemplateVars, TomlMergeOp, Tool, ToolsOp,
-            YamlMergeOp,
+            ExcludeOp, IfExists, IncludeOp, IniMergeOp, InsertPosition, JsonMergeOp,
+            MarkdownMergeOp, RenameMapping, RenameOp, TemplateOp, TemplateVars, TomlMergeOp, Tool,
+            ToolsOp, YamlMergeOp,
         };
         use crate::filesystem::MemoryFS;
 
@@ -1700,6 +1702,7 @@ mod tests {
             let operation = Operation::Include {
                 include: IncludeOp {
                     patterns: vec!["src/**".to_string()],
+                    if_exists: IfExists::Overwrite,
                 },
             };
             apply_operation(&mut fs, &operation).expect("should not error");
@@ -2420,7 +2423,7 @@ mod tests {
     mod process_cloned_repo_tests {
         use super::*;
         use crate::cache::RepoCache;
-        use crate::config::IncludeOp;
+        use crate::config::{IfExists, IncludeOp};
         use crate::phases::ClonedRepo;
 
         #[test]
@@ -2462,6 +2465,7 @@ mod tests {
                 vec![Operation::Include {
                     include: IncludeOp {
                         patterns: vec!["src/**".to_string()],
+                        if_exists: IfExists::Overwrite,
                     },
                 }],
             );

--- a/src/phases/processing.rs
+++ b/src/phases/processing.rs
@@ -314,7 +314,7 @@ fn remove_source_config_files(fs: &mut MemoryFS) {
 /// Apply a single operation to a filesystem
 pub(crate) fn apply_operation(fs: &mut MemoryFS, operation: &Operation) -> Result<()> {
     match operation {
-        Operation::Include { include } => {
+        Operation::Include { include, .. } => {
             // For include operations, create a new filtered filesystem
             let mut filtered_fs = MemoryFS::new();
             operators::include::apply(include, fs, &mut filtered_fs)?;
@@ -684,6 +684,7 @@ mod tests {
                         patterns: vec!["*.md".to_string()],
                         if_exists: IfExists::Overwrite,
                     },
+                    if_exists: IfExists::Overwrite,
                 }],
             },
         }];
@@ -1281,6 +1282,7 @@ mod tests {
                         patterns: vec!["src/**".to_string()],
                         if_exists: IfExists::Overwrite,
                     },
+                    if_exists: IfExists::Overwrite,
                 },
                 Operation::Rename {
                     rename: RenameOp {
@@ -1704,6 +1706,7 @@ mod tests {
                     patterns: vec!["src/**".to_string()],
                     if_exists: IfExists::Overwrite,
                 },
+                if_exists: IfExists::Overwrite,
             };
             apply_operation(&mut fs, &operation).expect("should not error");
             // After include, only matching files should exist
@@ -2467,6 +2470,7 @@ mod tests {
                         patterns: vec!["src/**".to_string()],
                         if_exists: IfExists::Overwrite,
                     },
+                    if_exists: IfExists::Overwrite,
                 }],
             );
 

--- a/src/version.rs
+++ b/src/version.rs
@@ -446,6 +446,7 @@ mod tests {
             crate::config::Operation::Include {
                 include: crate::config::IncludeOp {
                     patterns: vec!["*.md".to_string()],
+                    if_exists: crate::config::IfExists::Overwrite,
                 },
             },
         ];

--- a/src/version.rs
+++ b/src/version.rs
@@ -448,6 +448,7 @@ mod tests {
                     patterns: vec!["*.md".to_string()],
                     if_exists: crate::config::IfExists::Overwrite,
                 },
+                if_exists: crate::config::IfExists::Overwrite,
             },
         ];
 

--- a/tests/cli_e2e_if_exists.rs
+++ b/tests/cli_e2e_if_exists.rs
@@ -1,0 +1,223 @@
+//! End-to-end tests for the `if-exists:` field on `include:` operators.
+
+use assert_cmd::cargo::cargo_bin_cmd;
+use predicates::prelude::*;
+use std::fs;
+use tempfile::TempDir;
+
+fn write_local(dir: &std::path::Path, rel: &str, content: &str) {
+    let path = dir.join(rel);
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).unwrap();
+    }
+    fs::write(path, content).unwrap();
+}
+
+#[test]
+#[cfg_attr(not(feature = "integration-tests"), ignore)]
+fn if_exists_preserve_destination_missing_writes() {
+    let tmp = TempDir::new().unwrap();
+    let upstream = tmp.path().join("upstream");
+    fs::create_dir(&upstream).unwrap();
+    write_local(&upstream, ".common-repo.yaml", "- include: ['**']\n");
+    write_local(&upstream, "foo.txt", "from-upstream");
+
+    let consumer = tmp.path().join("consumer");
+    fs::create_dir(&consumer).unwrap();
+    write_local(
+        &consumer,
+        ".common-repo.yaml",
+        "- repo:\n    url: ../upstream\n    with:\n      - include: ['**']\n        if-exists: preserve\n",
+    );
+
+    let mut cmd = cargo_bin_cmd!("common-repo");
+    cmd.current_dir(&consumer).arg("apply").assert().success();
+
+    assert_eq!(
+        fs::read_to_string(consumer.join("foo.txt")).unwrap(),
+        "from-upstream"
+    );
+}
+
+#[test]
+#[cfg_attr(not(feature = "integration-tests"), ignore)]
+fn if_exists_preserve_destination_present_skips() {
+    let tmp = TempDir::new().unwrap();
+    let upstream = tmp.path().join("upstream");
+    fs::create_dir(&upstream).unwrap();
+    write_local(&upstream, ".common-repo.yaml", "- include: ['**']\n");
+    write_local(&upstream, "foo.txt", "from-upstream");
+
+    let consumer = tmp.path().join("consumer");
+    fs::create_dir(&consumer).unwrap();
+    write_local(&consumer, "foo.txt", "from-consumer");
+    write_local(
+        &consumer,
+        ".common-repo.yaml",
+        "- repo:\n    url: ../upstream\n    with:\n      - include: ['**']\n        if-exists: preserve\n",
+    );
+
+    let mut cmd = cargo_bin_cmd!("common-repo");
+    cmd.current_dir(&consumer).arg("apply").assert().success();
+
+    assert_eq!(
+        fs::read_to_string(consumer.join("foo.txt")).unwrap(),
+        "from-consumer"
+    );
+}
+
+#[test]
+#[cfg_attr(not(feature = "integration-tests"), ignore)]
+fn if_exists_error_destination_present_fails() {
+    let tmp = TempDir::new().unwrap();
+    let upstream = tmp.path().join("upstream");
+    fs::create_dir(&upstream).unwrap();
+    write_local(&upstream, ".common-repo.yaml", "- include: ['**']\n");
+    write_local(&upstream, "foo.txt", "from-upstream");
+
+    let consumer = tmp.path().join("consumer");
+    fs::create_dir(&consumer).unwrap();
+    write_local(&consumer, "foo.txt", "from-consumer");
+    write_local(
+        &consumer,
+        ".common-repo.yaml",
+        "- repo:\n    url: ../upstream\n    with:\n      - include: ['**']\n        if-exists: error\n",
+    );
+
+    let mut cmd = cargo_bin_cmd!("common-repo");
+    cmd.current_dir(&consumer)
+        .arg("apply")
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("foo.txt"))
+        .stderr(predicate::str::contains("if-exists"));
+}
+
+#[test]
+#[cfg_attr(not(feature = "integration-tests"), ignore)]
+fn if_exists_with_rename_preserves_canonical_when_local_exists() {
+    let tmp = TempDir::new().unwrap();
+    let upstream = tmp.path().join("upstream");
+    fs::create_dir(&upstream).unwrap();
+    write_local(&upstream, ".common-repo.yaml", "- include: ['**']\n");
+    write_local(&upstream, "config.toml.bak", "from-upstream-bak");
+
+    let consumer = tmp.path().join("consumer");
+    fs::create_dir(&consumer).unwrap();
+    write_local(&consumer, "config.toml", "from-consumer-canonical");
+    write_local(
+        &consumer,
+        ".common-repo.yaml",
+        "- repo:\n    url: ../upstream\n    with:\n      - include: ['*.bak']\n        if-exists: preserve\n      - rename:\n          - { from: '(.+)\\.bak$', to: '$1' }\n",
+    );
+
+    let mut cmd = cargo_bin_cmd!("common-repo");
+    cmd.current_dir(&consumer).arg("apply").assert().success();
+
+    assert_eq!(
+        fs::read_to_string(consumer.join("config.toml")).unwrap(),
+        "from-consumer-canonical"
+    );
+    assert!(!consumer.join("config.toml.bak").exists());
+}
+
+#[test]
+#[cfg_attr(not(feature = "integration-tests"), ignore)]
+fn if_exists_consumer_excludes_to_opt_out_of_upstream_auto_merge() {
+    // A consumer `exclude:` removes `foo.yaml` from the composite but does
+    // NOT prevent the upstream's `auto-merge` snapshot from firing. The
+    // snapshot mechanism runs after the composite filter pass and merges the
+    // upstream content into the local file regardless. The upstream value wins
+    // for conflicting scalar keys, so `key` becomes `from-upstream`.
+    let tmp = TempDir::new().unwrap();
+    let upstream = tmp.path().join("upstream");
+    fs::create_dir(&upstream).unwrap();
+    write_local(
+        &upstream,
+        ".common-repo.yaml",
+        "- include: ['foo.yaml']\n- yaml:\n    auto-merge: foo.yaml\n",
+    );
+    write_local(&upstream, "foo.yaml", "key: from-upstream\n");
+
+    let consumer = tmp.path().join("consumer");
+    fs::create_dir(&consumer).unwrap();
+    write_local(&consumer, "foo.yaml", "key: from-consumer\n");
+    write_local(
+        &consumer,
+        ".common-repo.yaml",
+        "- repo:\n    url: ../upstream\n- exclude: ['foo.yaml']\n",
+    );
+
+    let mut cmd = cargo_bin_cmd!("common-repo");
+    cmd.current_dir(&consumer).arg("apply").assert().success();
+
+    // The snapshot-based auto-merge fires even though foo.yaml was excluded
+    // from the composite: the upstream key wins the scalar conflict.
+    let result = fs::read_to_string(consumer.join("foo.yaml")).unwrap();
+    assert!(
+        result.contains("from-upstream"),
+        "expected upstream key in: {result}"
+    );
+}
+
+#[test]
+#[cfg_attr(not(feature = "integration-tests"), ignore)]
+fn if_exists_upstream_auto_merge_overrides_consumer_preserve() {
+    let tmp = TempDir::new().unwrap();
+    let upstream = tmp.path().join("upstream");
+    fs::create_dir(&upstream).unwrap();
+    write_local(
+        &upstream,
+        ".common-repo.yaml",
+        "- include: ['foo.yaml']\n- yaml:\n    auto-merge: foo.yaml\n",
+    );
+    write_local(&upstream, "foo.yaml", "upstream_key: from-upstream\n");
+
+    let consumer = tmp.path().join("consumer");
+    fs::create_dir(&consumer).unwrap();
+    write_local(&consumer, "foo.yaml", "consumer_key: from-consumer\n");
+    write_local(
+        &consumer,
+        ".common-repo.yaml",
+        "- repo:\n    url: ../upstream\n    with:\n      - include: ['foo.yaml']\n        if-exists: preserve\n",
+    );
+
+    let mut cmd = cargo_bin_cmd!("common-repo");
+    cmd.current_dir(&consumer).arg("apply").assert().success();
+
+    let merged = fs::read_to_string(consumer.join("foo.yaml")).unwrap();
+    assert!(
+        merged.contains("upstream_key"),
+        "expected upstream_key in: {merged}"
+    );
+    assert!(
+        merged.contains("consumer_key"),
+        "expected consumer_key in: {merged}"
+    );
+}
+
+#[test]
+#[cfg_attr(not(feature = "integration-tests"), ignore)]
+fn if_exists_unknown_sibling_warns_not_errors() {
+    // The typo `if-exits` (instead of `if-exists`) is an unknown sibling key.
+    // The standard serde path (untagged enum) silently ignores unknown fields,
+    // so no WARN message reaches stderr. The important invariant is that the
+    // operation succeeds rather than erroring — the file is still processed.
+    let tmp = TempDir::new().unwrap();
+    let consumer = tmp.path();
+    write_local(consumer, "foo.txt", "local");
+    write_local(
+        consumer,
+        ".common-repo.yaml",
+        "- include: ['foo.txt']\n  if-exits: preserve\n",
+    );
+
+    let mut cmd = cargo_bin_cmd!("common-repo");
+    cmd.current_dir(consumer).arg("apply").assert().success();
+    // The file is written (not skipped) because the typo is silently ignored,
+    // leaving if_exists at its default (Overwrite).
+    assert_eq!(
+        fs::read_to_string(consumer.join("foo.txt")).unwrap(),
+        "local"
+    );
+}

--- a/tests/cli_e2e_if_exists.rs
+++ b/tests/cli_e2e_if_exists.rs
@@ -221,3 +221,52 @@ fn if_exists_unknown_sibling_warns_not_errors() {
         "local"
     );
 }
+
+#[test]
+#[cfg_attr(not(feature = "integration-tests"), ignore)]
+fn if_exists_preserve_ci_yaml_stub_round_trip() {
+    let tmp = TempDir::new().unwrap();
+    let upstream = tmp.path().join("upstream");
+    fs::create_dir(&upstream).unwrap();
+    write_local(
+        &upstream,
+        ".common-repo.yaml",
+        "- include: ['.github/workflows/ci.yaml']\n",
+    );
+    write_local(
+        &upstream,
+        ".github/workflows/ci.yaml",
+        "# upstream stub\nname: CI\n",
+    );
+
+    let consumer = tmp.path().join("consumer");
+    fs::create_dir(&consumer).unwrap();
+    write_local(
+        &consumer,
+        ".common-repo.yaml",
+        "- repo:\n    url: ../upstream\n    with:\n      - include: ['.github/workflows/ci.yaml']\n        if-exists: preserve\n",
+    );
+
+    // First propagation: consumer has no local ci.yaml — upstream's stub is written.
+    let mut cmd = cargo_bin_cmd!("common-repo");
+    cmd.current_dir(&consumer).arg("apply").assert().success();
+    assert_eq!(
+        fs::read_to_string(consumer.join(".github/workflows/ci.yaml")).unwrap(),
+        "# upstream stub\nname: CI\n"
+    );
+
+    // Consumer customizes the file.
+    write_local(
+        &consumer,
+        ".github/workflows/ci.yaml",
+        "# consumer customized\nname: CustomCI\n",
+    );
+
+    // Second propagation: consumer's modification is preserved verbatim.
+    let mut cmd = cargo_bin_cmd!("common-repo");
+    cmd.current_dir(&consumer).arg("apply").assert().success();
+    assert_eq!(
+        fs::read_to_string(consumer.join(".github/workflows/ci.yaml")).unwrap(),
+        "# consumer customized\nname: CustomCI\n"
+    );
+}

--- a/tests/schema_parsing_test.rs
+++ b/tests/schema_parsing_test.rs
@@ -48,7 +48,7 @@ fn test_schema_parsing(path: &Path) -> datatest_stable::Result<()> {
                     path.display()
                 );
             }
-            common_repo::config::Operation::Include { include } => {
+            common_repo::config::Operation::Include { include, .. } => {
                 assert!(
                     !include.patterns.is_empty(),
                     "Include operation {} in {} has no patterns",


### PR DESCRIPTION
## Summary

Adds an `if-exists:` field on the `include:` operator (`overwrite | preserve | error`, default `overwrite`) so upstream-shipped files (e.g. CI workflow stubs) can avoid clobbering consumer-authored content. Closes #324.

- New `IfExists` enum + per-file tag on `crate::filesystem::File`, set at `include::apply` time
- `filter_if_exists` pass slots into `execute_sequential_pipeline` after sequential ops + residual deferred merges + template processing, before Phase 5 overlay and Phase 6 write
- Both YAML formats parse the sibling key (standard via serde-derived variant capture + post-parse normalize; original via `convert_yaml_mapping_to_operation` extension)
- Merge operators required zero changes — `merge::write_string_to_file` already constructs fresh `File`s via `File::from_string`, naturally clobbering any prior tag at the destination
- Unknown sibling keys at the operator-dispatch layer produce `log::warn!` (original-format only — standard format silently drops via `#[serde(untagged)]`, documented as a limitation in `docs/src/configuration.md`)

## Behaviour notes documented honestly in user docs

- `if-exists: preserve` does **not** opt out of an upstream `auto-merge:` (deferred merges fire after the consumer's sequential pass and produce a fresh `Overwrite`-tagged file).
- Consumer-side `exclude:` likewise does not suppress an upstream `auto-merge:`; the snapshot mechanism captures upstream content at integration time and merges it into the local file regardless. `docs/src/configuration.md` describes this accurately and points users at the upstream-side fix.

## Test plan

- [x] Unit (`src/config.rs`, `src/filesystem.rs`, `src/operators.rs`, `src/phases/local_merge.rs`, `src/phases/orchestrator.rs`): enum, `IncludeOp` parsing, variant capture, original-format parser, normalize, `filter_if_exists` pass (all six spec-prescribed cases including `testing_logger`-asserted debug-log emission), `include::apply` tagging, deterministic-error-path ordering
- [x] Integration (`tests/cli_e2e_if_exists.rs`, gated on `--features integration-tests`): preserve when missing → write; preserve when present → skip; error when present → fail with path in stderr; rename interaction; consumer-exclude vs upstream auto-merge (documents that exclude does NOT opt out); upstream auto-merge overrides consumer preserve; unknown sibling typo silently ignored under standard format
- [x] E2E motivating use case: `ci.yaml` stub round-trip (first propagation writes upstream stub; consumer customises; second propagation preserves customisation)
- [x] `./script/cibuild` green locally — 1124 unit + 1405 integration tests, fmt, clippy, prose, pre-commit