### PR TITLE
feat(observability): add trace logging + three-tier-merge fixture

### DIFF
--- a/context/expected-fixture-convention.md
+++ b/context/expected-fixture-convention.md
@@ -1,0 +1,123 @@
+# Convention: `<name>.expected/` byte-exact apply fixtures
+
+A test convention for verifying that `common-repo apply` produces an exact
+filesystem result, comparable file-by-file. Use this instead of capturing
+output into Rust assertions — those drift away from the spec because the
+"expected" values get whatever the implementation happens to produce on first
+run.
+
+## Layout
+
+A fixture root contains zero or more sibling directories whose names end in
+`.expected`. Each is a self-contained mini-fixture:
+
+- `<name>.expected/.common-repo.yaml` — the input config.
+- `<name>.expected/<rel-path>` — every file the apply must produce, byte-exact.
+
+Other siblings of the fixture root (typically the upstream definitions being
+inherited) are referenced from the input config via the `__FIXTURE__`
+placeholder, which the runner substitutes with the absolute path of the
+fixture root before running apply.
+
+Example layout:
+
+```
+tests/testdata/some-fixture/
+  upstream-base/                      ← upstream definition (consumed via repo:)
+    .common-repo.yaml
+    merge.yaml
+  upstream-base.expected/             ← consumer fixture #1
+    .common-repo.yaml                 ← `- repo: { url: __FIXTURE__/upstream-base }`
+    merge.yaml                        ← byte-exact expected output
+  consumer.expected/                  ← consumer fixture #2
+    .common-repo.yaml
+    merge.yaml
+    .github/workflows/ci.yaml         ← any path under .expected/ is checked
+```
+
+`upstream-base/` here exists only as a consumable upstream — apply is never
+run there. If a tier needs to be tested both as a definition and as a
+consumer of itself, add a separate `<tier>.expected/` whose config does the
+self-application.
+
+## Runner
+
+`tests/common/expected_fixture.rs` provides:
+
+```rust
+pub fn run_expected_fixtures(fixture_root: &Path);
+```
+
+The runner discovers every `*.expected/` directly under `fixture_root` and,
+for each:
+
+1. Creates a fresh tempdir.
+2. Reads `<name>.expected/.common-repo.yaml`, replaces every literal
+   `__FIXTURE__` with the canonicalized absolute path of `fixture_root`,
+   writes the result into the tempdir.
+3. Runs `common-repo apply` in the tempdir. Failure of apply fails the test.
+4. Walks `<name>.expected/` and asserts every file is byte-identical to the
+   corresponding tempdir file. Missing files fail with a clear message.
+5. Walks the tempdir and fails if any file outside the expected set was
+   produced. Catches over-creation.
+
+`.git/` and `.common-repo-cache/` are ignored on both sides. The input
+`.common-repo.yaml` is excluded from byte comparison because the runner
+templates it.
+
+## Using the runner
+
+A test file is two lines of body:
+
+```rust
+mod common;
+use common::expected_fixture::run_expected_fixtures;
+use std::path::Path;
+
+#[test]
+#[cfg_attr(not(feature = "integration-tests"), ignore)]
+fn some_fixture_apply_matches_expected() {
+    let fixture = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("tests")
+        .join("testdata")
+        .join("some-fixture");
+    run_expected_fixtures(&fixture);
+}
+```
+
+## Failure output
+
+Mismatches panic with one or more of:
+
+- `missing: <rel> — expected file was not produced by apply`
+- `unexpected: <rel> — apply produced a file not listed in the expected fixture`
+- `content mismatch: <rel>` followed by byte counts and quoted snippets of
+  both sides.
+
+The messages are designed to be eyeballable. For larger diffs, run
+`diff -ru` against the tempdir directly while debugging.
+
+## When to use which fixture style
+
+| Style | Use when |
+|-------|----------|
+| `<name>.expected/` byte-exact | The output is deterministic and the spec defines exactly what files should exist with what content. Best for integration-style tests of merge, rename, include semantics. |
+| Captured Rust assertions | Avoid for new work. Treat existing ones as legacy and migrate when convenient. |
+| Property-based / shape assertions | When only a property is specified (e.g., "merge.yaml exists and parses as YAML with key X") rather than the full byte sequence. |
+
+## Self-test
+
+`tests/cli_e2e_expected_runner.rs` runs the runner against
+`tests/testdata/expected-runner-selftest/`, a minimal two-directory fixture
+that consumes a local source via `repo: __FIXTURE__/source`. Confirms both
+the happy path and (during initial development) the negative path.
+
+## Extension axes (not yet implemented)
+
+If a tier needs different expected outputs for self-block apply vs.
+source-block consumption, the convention can extend to `<name>.exposed/` for
+the source-block view. Not needed today — flag it here so we don't reinvent.
+
+If allowlisting non-checked files is needed (e.g., expected metadata that
+varies by run), add a `<name>.expected/.expected-allow-extra` file with one
+glob per line. Not implemented yet.

--- a/src/merge/yaml.rs
+++ b/src/merge/yaml.rs
@@ -23,7 +23,7 @@
 //! apply_yaml_merge_operation(&mut fs, &op)?;
 //! ```
 
-use log::warn;
+use log::{trace, warn};
 use serde_yaml::Value as YamlValue;
 
 use super::{read_file_as_string, read_file_as_string_optional, write_string_to_file, PathSegment};
@@ -326,6 +326,18 @@ pub fn apply_yaml_merge_operation(fs: &mut MemoryFS, op: &YamlMergeOp) -> Result
     op.validate()?;
     let source_path = op.get_source().expect("source validated");
     let dest_path = op.get_dest().expect("dest validated");
+
+    trace!(
+        "yaml merge: source={}, dest={}, mode={:?}, position={:?}, path={:?}, auto_merge={}, source_in_fs={}, dest_in_fs={}",
+        source_path,
+        dest_path,
+        op.array_mode,
+        op.position,
+        op.path,
+        op.auto_merge.is_some(),
+        fs.exists(source_path),
+        fs.exists(dest_path),
+    );
 
     // MissingSourceAutoMerge: auto-merge where neither side has the file -> warn and skip
     if op.auto_merge.is_some() && !fs.exists(source_path) && !fs.exists(dest_path) {

--- a/src/operators.rs
+++ b/src/operators.rs
@@ -32,6 +32,7 @@ use crate::error::Result;
 use crate::filesystem::MemoryFS;
 use crate::path::regex_rename;
 use crate::repository::RepositoryManager;
+use log::trace;
 use std::path::Path;
 
 /// Include operator - adds files matching glob patterns to the filesystem
@@ -62,11 +63,27 @@ pub(crate) mod include {
     pub(crate) fn apply(op: &IncludeOp, source: &MemoryFS, target: &mut MemoryFS) -> Result<()> {
         for pattern in &op.patterns {
             let matching_files = source.list_files_glob(pattern)?;
+            trace!(
+                "include: pattern={} matched {} files",
+                pattern,
+                matching_files.len(),
+            );
 
             for path in matching_files {
                 if let Some(file) = source.get_file(&path) {
                     let mut file = file.clone();
                     file.if_exists = op.if_exists;
+                    let already = target.exists(&path);
+                    trace!(
+                        "include: + {} ({} bytes){}",
+                        path.display(),
+                        file.content.len(),
+                        if already {
+                            " [overwrites existing]"
+                        } else {
+                            ""
+                        },
+                    );
                     target.add_file(&path, file)?;
                 }
             }
@@ -95,8 +112,14 @@ pub(crate) mod exclude {
     pub(crate) fn apply(op: &ExcludeOp, target: &mut MemoryFS) -> Result<()> {
         for pattern in &op.patterns {
             let matching_files = target.list_files_glob(pattern)?;
+            trace!(
+                "exclude: pattern={} matched {} files",
+                pattern,
+                matching_files.len(),
+            );
 
             for path in matching_files {
+                trace!("exclude: - {}", path.display());
                 target.remove_file(&path)?;
             }
         }
@@ -144,6 +167,13 @@ pub(crate) mod rename {
 
             // Perform the renames
             for (old_path, new_path) in files_to_rename {
+                trace!(
+                    "rename: {} -> {}  (regex: {} -> {})",
+                    old_path.display(),
+                    new_path.display(),
+                    from_pattern,
+                    to_pattern,
+                );
                 target.rename_file(&old_path, &new_path)?;
             }
         }

--- a/tests/cli_e2e_expected_fixture.rs
+++ b/tests/cli_e2e_expected_fixture.rs
@@ -1,0 +1,24 @@
+//! Self-test for the `*.expected/` byte-exact fixture runner.
+//!
+//! See `tests/common/expected_fixture.rs` for the convention. This file
+//! exercises the runner against a minimal fixture under
+//! `tests/testdata/expected-fixture-selftest/` to confirm:
+//!
+//! - The runner discovers `<name>.expected/` directories.
+//! - It substitutes the `__FIXTURE__` placeholder in the input config.
+//! - It runs `common-repo apply` and asserts byte-exact output.
+
+mod common;
+
+use common::expected_fixture::run_expected_fixtures;
+use std::path::Path;
+
+#[test]
+#[cfg_attr(not(feature = "integration-tests"), ignore)]
+fn expected_fixture_runner_runs_minimal_fixture() {
+    let fixture = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("tests")
+        .join("testdata")
+        .join("expected-fixture-selftest");
+    run_expected_fixtures(&fixture);
+}

--- a/tests/cli_e2e_three_tier_merge.rs
+++ b/tests/cli_e2e_three_tier_merge.rs
@@ -1,0 +1,19 @@
+//! Three-tier auto-merge regression: upstream contributes a yaml file plus
+//! an extra file, source adds a yaml fragment plus a third file, and the
+//! consumer holds a base yaml at the same path. Expected output: merged
+//! yaml carries all three tiers' sections; both extra files are present.
+
+mod common;
+
+use common::expected_fixture::run_expected_fixtures;
+use std::path::Path;
+
+#[test]
+#[cfg_attr(not(feature = "integration-tests"), ignore)]
+fn consumer_merges_three_tiers() {
+    let fixture = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("tests")
+        .join("testdata")
+        .join("three-tier-merge");
+    run_expected_fixtures(&fixture);
+}

--- a/tests/common/expected_fixture.rs
+++ b/tests/common/expected_fixture.rs
@@ -1,0 +1,208 @@
+//! Byte-exact apply verification using `<name>.expected/` fixtures.
+//!
+//! ## Convention
+//!
+//! A fixture root contains zero or more sibling directories whose names end in
+//! `.expected`. Each is a self-contained mini-fixture: a `.common-repo.yaml`
+//! input and the byte-exact files that `common-repo apply` should produce when
+//! run against that config.
+//!
+//! Other siblings of the fixture root (typically used as upstreams) are
+//! referenced from the input config via the `__FIXTURE__` placeholder. The
+//! runner substitutes it with the absolute path of the fixture root before
+//! running apply.
+//!
+//! ## What the runner does
+//!
+//! For each `<name>.expected/`:
+//!
+//! 1. Create a fresh tempdir.
+//! 2. Read `<name>.expected/.common-repo.yaml`, substitute `__FIXTURE__` with
+//!    the absolute fixture-root path, write the result to the tempdir.
+//! 3. Run `common-repo apply` in the tempdir.
+//! 4. Walk `<name>.expected/` (excluding `.common-repo.yaml`, which we
+//!    templated and is allowed to differ) and assert every file is
+//!    byte-identical to the corresponding file in the tempdir.
+//! 5. Walk the tempdir and fail if any file outside the expected set was
+//!    produced (catches over-creation).
+//!
+//! `.git/` and `.common-repo-cache/` paths are ignored on both sides.
+
+use std::collections::BTreeSet;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use assert_cmd::cargo::cargo_bin_cmd;
+use tempfile::TempDir;
+
+const FIXTURE_PLACEHOLDER: &str = "__FIXTURE__";
+const CONFIG_FILE: &str = ".common-repo.yaml";
+const IGNORED_PREFIXES: &[&str] = &[".git/", ".common-repo-cache/"];
+
+/// Discover every `<name>.expected/` directory directly under `fixture_root`,
+/// run apply against each, and assert the resulting tempdir matches byte-for-byte.
+/// Panics on any mismatch with a unified-style summary.
+pub fn run_expected_fixtures(fixture_root: &Path) {
+    let cases = discover_expected_dirs(fixture_root);
+    assert!(
+        !cases.is_empty(),
+        "no `*.expected/` directories found under {}",
+        fixture_root.display()
+    );
+    for expected_dir in cases {
+        run_one(fixture_root, &expected_dir);
+    }
+}
+
+fn discover_expected_dirs(fixture_root: &Path) -> Vec<PathBuf> {
+    let mut out = Vec::new();
+    let entries = fs::read_dir(fixture_root).unwrap_or_else(|e| {
+        panic!(
+            "failed to read fixture root {}: {e}",
+            fixture_root.display()
+        )
+    });
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if !path.is_dir() {
+            continue;
+        }
+        let name = match path.file_name().and_then(|n| n.to_str()) {
+            Some(n) => n,
+            None => continue,
+        };
+        if name.ends_with(".expected") {
+            out.push(path);
+        }
+    }
+    out.sort();
+    out
+}
+
+fn run_one(fixture_root: &Path, expected_dir: &Path) {
+    let temp = TempDir::new().expect("failed to create tempdir");
+    write_templated_config(fixture_root, expected_dir, temp.path());
+
+    let mut cmd = cargo_bin_cmd!("common-repo");
+    cmd.current_dir(temp.path()).arg("apply").assert().success();
+
+    assert_tree_matches(temp.path(), expected_dir);
+}
+
+fn write_templated_config(fixture_root: &Path, expected_dir: &Path, dest_dir: &Path) {
+    let src = expected_dir.join(CONFIG_FILE);
+    let raw = fs::read_to_string(&src)
+        .unwrap_or_else(|e| panic!("failed to read {}: {e}", src.display()));
+    let absolute_root = fixture_root.canonicalize().unwrap_or_else(|e| {
+        panic!(
+            "failed to canonicalize fixture root {}: {e}",
+            fixture_root.display()
+        )
+    });
+    let abs_str = absolute_root
+        .to_str()
+        .expect("fixture root path is not valid UTF-8");
+    let templated = raw.replace(FIXTURE_PLACEHOLDER, abs_str);
+    fs::write(dest_dir.join(CONFIG_FILE), templated)
+        .unwrap_or_else(|e| panic!("failed to write tempdir {CONFIG_FILE}: {e}"));
+}
+
+fn assert_tree_matches(actual_dir: &Path, expected_dir: &Path) {
+    let expected_files = collect_relative_paths(expected_dir);
+    let actual_files = collect_relative_paths(actual_dir);
+    let config_rel = PathBuf::from(CONFIG_FILE);
+
+    let mut errors: Vec<String> = Vec::new();
+
+    for rel in &expected_files {
+        if rel == &config_rel {
+            continue;
+        }
+        let expected_path = expected_dir.join(rel);
+        let actual_path = actual_dir.join(rel);
+        if !actual_path.exists() {
+            errors.push(format!(
+                "missing: {} — expected file was not produced by apply",
+                rel.display()
+            ));
+            continue;
+        }
+        let expected_bytes = fs::read(&expected_path)
+            .unwrap_or_else(|e| panic!("failed to read {}: {e}", expected_path.display()));
+        let actual_bytes = fs::read(&actual_path)
+            .unwrap_or_else(|e| panic!("failed to read {}: {e}", actual_path.display()));
+        if expected_bytes != actual_bytes {
+            errors.push(format!(
+                "content mismatch: {}\n  expected ({} bytes): {}\n  actual   ({} bytes): {}",
+                rel.display(),
+                expected_bytes.len(),
+                summarize_bytes(&expected_bytes),
+                actual_bytes.len(),
+                summarize_bytes(&actual_bytes),
+            ));
+        }
+    }
+
+    for rel in &actual_files {
+        if rel == &config_rel || expected_files.contains(rel) {
+            continue;
+        }
+        errors.push(format!(
+            "unexpected: {} — apply produced a file not listed in the expected fixture",
+            rel.display()
+        ));
+    }
+
+    if !errors.is_empty() {
+        panic!(
+            "expected fixture mismatch in {}:\n  {}",
+            expected_dir.display(),
+            errors.join("\n  ")
+        );
+    }
+}
+
+fn collect_relative_paths(root: &Path) -> BTreeSet<PathBuf> {
+    let mut out = BTreeSet::new();
+    walk(root, root, &mut out);
+    out
+}
+
+fn walk(root: &Path, dir: &Path, out: &mut BTreeSet<PathBuf>) {
+    let entries = match fs::read_dir(dir) {
+        Ok(it) => it,
+        Err(_) => return,
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        let rel = match path.strip_prefix(root) {
+            Ok(r) => r.to_path_buf(),
+            Err(_) => continue,
+        };
+        if is_ignored(&rel) {
+            continue;
+        }
+        if path.is_dir() {
+            walk(root, &path, out);
+        } else if path.is_file() {
+            out.insert(rel);
+        }
+    }
+}
+
+fn is_ignored(rel: &Path) -> bool {
+    let s = rel.to_string_lossy();
+    IGNORED_PREFIXES
+        .iter()
+        .any(|prefix| s.starts_with(prefix) || s == prefix.trim_end_matches('/'))
+}
+
+fn summarize_bytes(bytes: &[u8]) -> String {
+    const MAX: usize = 200;
+    let text = String::from_utf8_lossy(bytes);
+    if text.len() <= MAX {
+        format!("{text:?}")
+    } else {
+        format!("{:?}…", &text[..MAX])
+    }
+}

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -24,6 +24,9 @@ use std::env;
 use std::path::Path;
 use std::process::Command;
 
+#[allow(dead_code)]
+pub mod expected_fixture;
+
 /// Re-export commonly used test dependencies for convenience.
 #[allow(unused_imports)]
 pub mod prelude {

--- a/tests/testdata/expected-fixture-selftest/source.expected/.common-repo.yaml
+++ b/tests/testdata/expected-fixture-selftest/source.expected/.common-repo.yaml
@@ -1,0 +1,2 @@
+- repo:
+    url: __FIXTURE__/source

--- a/tests/testdata/expected-fixture-selftest/source.expected/hello.txt
+++ b/tests/testdata/expected-fixture-selftest/source.expected/hello.txt
@@ -1,0 +1,1 @@
+hello world

--- a/tests/testdata/expected-fixture-selftest/source/.common-repo.yaml
+++ b/tests/testdata/expected-fixture-selftest/source/.common-repo.yaml
@@ -1,0 +1,1 @@
+- include: ["hello.txt"]

--- a/tests/testdata/expected-fixture-selftest/source/hello.txt
+++ b/tests/testdata/expected-fixture-selftest/source/hello.txt
@@ -1,0 +1,1 @@
+hello world

--- a/tests/testdata/three-tier-merge/consumer-base/.common-repo.yaml
+++ b/tests/testdata/three-tier-merge/consumer-base/.common-repo.yaml
@@ -1,0 +1,6 @@
+- repo:
+    url: ../source
+- include: ['**']
+- yaml:
+    auto-merge: merge.yaml
+    array_mode: append_unique

--- a/tests/testdata/three-tier-merge/consumer-base/merge.yaml
+++ b/tests/testdata/three-tier-merge/consumer-base/merge.yaml
@@ -1,0 +1,4 @@
+consumer_id: 3
+items:
+- con
+- common

--- a/tests/testdata/three-tier-merge/consumer.expected/.common-repo.yaml
+++ b/tests/testdata/three-tier-merge/consumer.expected/.common-repo.yaml
@@ -1,0 +1,2 @@
+- repo:
+    url: __FIXTURE__/consumer-base

--- a/tests/testdata/three-tier-merge/consumer.expected/extra-from-source.txt
+++ b/tests/testdata/three-tier-merge/consumer.expected/extra-from-source.txt
@@ -1,0 +1,1 @@
+extra from source

--- a/tests/testdata/three-tier-merge/consumer.expected/extra-from-upstream.txt
+++ b/tests/testdata/three-tier-merge/consumer.expected/extra-from-upstream.txt
@@ -1,0 +1,1 @@
+extra from upstream

--- a/tests/testdata/three-tier-merge/consumer.expected/merge.yaml
+++ b/tests/testdata/three-tier-merge/consumer.expected/merge.yaml
@@ -1,0 +1,8 @@
+consumer_id: 3
+items:
+- con
+- common
+- src
+- up
+source_id: 2
+upstream_id: 1

--- a/tests/testdata/three-tier-merge/source/.common-repo.yaml
+++ b/tests/testdata/three-tier-merge/source/.common-repo.yaml
@@ -1,0 +1,6 @@
+- repo:
+    url: ../upstream
+- include: ['**']
+- yaml:
+    auto-merge: merge.yaml
+    array_mode: append_unique

--- a/tests/testdata/three-tier-merge/source/extra-from-source.txt
+++ b/tests/testdata/three-tier-merge/source/extra-from-source.txt
@@ -1,0 +1,1 @@
+extra from source

--- a/tests/testdata/three-tier-merge/source/merge.yaml
+++ b/tests/testdata/three-tier-merge/source/merge.yaml
@@ -1,0 +1,4 @@
+source_id: 2
+items:
+- src
+- common

--- a/tests/testdata/three-tier-merge/upstream/.common-repo.yaml
+++ b/tests/testdata/three-tier-merge/upstream/.common-repo.yaml
@@ -1,0 +1,4 @@
+- include: ['**']
+- yaml:
+    auto-merge: merge.yaml
+    array_mode: append_unique

--- a/tests/testdata/three-tier-merge/upstream/extra-from-upstream.txt
+++ b/tests/testdata/three-tier-merge/upstream/extra-from-upstream.txt
@@ -1,0 +1,1 @@
+extra from upstream

--- a/tests/testdata/three-tier-merge/upstream/merge.yaml
+++ b/tests/testdata/three-tier-merge/upstream/merge.yaml
@@ -1,0 +1,4 @@
+upstream_id: 1
+items:
+- up
+- common


### PR DESCRIPTION
## Summary

Two small, independent additions that pave the way for the in-progress source-block-include-additive work:

- **Trace logging** in include/exclude/rename operators and the YAML merge entry point. At \`--log-level=trace\`, each per-file decision is now visible (\`include: + path (n bytes)\`, \`exclude: - path\`, \`rename: old -> new\`, plus a yaml-merge entry event with source/dest/mode/position). Enables stepping through pipeline behavior without attaching a debugger.

- **\`tests/testdata/three-tier-merge\`** — a three-tier byte-exact fixture (\`upstream\` → \`source\` → \`consumer-base\` → \`consumer.expected\`) that uses the recently-added \`<name>.expected/\` convention. Pins down the \`auto-merge\` + \`append_unique\` propagation through repo: integration across three levels.

This PR depends on \`455adcc\` (byte-exact apply runner) which is also included; it was committed earlier on the parent branch and rides along here.

## Test plan

- [x] \`cargo nextest run\` — 1145 unit tests pass
- [x] \`cargo nextest run --features integration-tests\` for the previously-touched suites (inheritance-merge, ls_filtering, sequential_ops, upstream_ops, three-tier-merge, expected_fixture selftest) — 58/58 pass
- [x] \`./script/ci\` — fmt, clippy, prose check pass (prek locally outdated but irrelevant for CI)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)