### PR TITLE
chore(release): hook cargo set-version into cog bump pre-bump

### DIFF
--- a/.common-repo.yaml
+++ b/.common-repo.yaml
@@ -13,3 +13,10 @@
     path: jobs.pre-commit.steps
     array_mode: append
     position: start
+
+- yaml:
+    source: .common-repo/release-rust-toolchain.yml
+    dest: .github/workflows/release.yaml
+    path: jobs.release.steps
+    array_mode: append
+    position: start

--- a/.common-repo/release-rust-toolchain.yml
+++ b/.common-repo/release-rust-toolchain.yml
@@ -1,0 +1,29 @@
+# Consumer-specific release workflow fragment.
+#
+# Installs the Rust toolchain and `cargo-edit` (which provides
+# `cargo set-version`) so the `pre_bump_hooks` in `cog.toml` can:
+#   1. `cargo set-version {{version}}` — update [workspace.package].version
+#   2. `cargo check --release`         — resync Cargo.lock
+#   3. `git add ...`                   — stage manifests + lockfile
+#
+# Without these steps the upstream release job has no cargo on PATH and
+# the bump commit would land with CHANGELOG.md changes only, leaving
+# Cargo.toml / Cargo.lock stuck at the previous version. That would also
+# make release-binaries.yaml build artifacts whose `--version` output
+# disagrees with the tarball filename.
+#
+# Wired into `.github/workflows/release.yaml` via a `yaml` merge op in
+# `.common-repo.yaml`:
+#   path: jobs.release.steps
+#   array_mode: append
+#   position: start
+# which prepends these steps to the upstream release job's step list on
+# every `common-repo apply`. Order within the job doesn't matter beyond
+# "before `cog bump --auto`" — `position: start` satisfies that trivially.
+- name: Install Rust
+  uses: dtolnay/rust-toolchain@stable
+
+- name: Install cargo-edit
+  uses: taiki-e/install-action@v2
+  with:
+    tool: cargo-edit

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,9 +1,15 @@
 [workspace]
 members = [".", "xtask"]
 
+# Shared package metadata. Workspace members opt in via `field.workspace = true`
+# (see `version` below). Keeps the release version in exactly one place so
+# `cargo set-version` in the cog pre-bump hook only has to touch this block.
+[workspace.package]
+version = "0.37.0"
+
 [package]
 name = "common-repo"
-version = "0.37.0"
+version.workspace = true
 edition = "2021"
 rust-version = "1.85.0"
 license = "AGPL-3.0-or-later"

--- a/cog.toml
+++ b/cog.toml
@@ -1,2 +1,25 @@
 tag_prefix = "v"
 ignore_merge_commits = true
+
+# Pre-bump hooks run after `cog bump` plans the next version but before it
+# creates the bump commit. `{{version}}` is the planned version.
+#
+# These keep the Cargo manifests and lockfile in sync with the tag cocogitto
+# is about to create. Without them, the release commit changes only
+# CHANGELOG.md and the published crate version drifts from the tag — which
+# also means release-binaries.yaml builds artifacts whose `--version` output
+# disagrees with the tarball filename.
+#
+# The version field is inherited workspace-wide via `[workspace.package]` in
+# Cargo.toml, so `cargo set-version` only edits a single line. `cargo check`
+# regenerates Cargo.lock with the new version. The explicit `git add` matches
+# the convention documented in the release workflow's bump step.
+#
+# `cargo set-version` is provided by the third-party `cargo-edit` crate; the
+# release workflow installs it via a consumer-specific fragment injected by
+# `.common-repo.yaml` into `jobs.release.steps`.
+pre_bump_hooks = [
+    "cargo set-version {{version}}",
+    "cargo check --release",
+    "git add Cargo.toml xtask/Cargo.toml Cargo.lock",
+]

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xtask"
-version = "0.37.0"
+version.workspace = true
 edition = "2021"
 rust-version = "1.85.0"
 description = "Development automation tasks for common-repo"


### PR DESCRIPTION
## Summary

- Move package version into `[workspace.package]` so `xtask` inherits it via `version.workspace = true`. `cargo set-version {{version}}` now touches a single line.
- Add `pre_bump_hooks` to `cog.toml` (`cargo set-version` → `cargo check --release` → `git add Cargo.toml xtask/Cargo.toml Cargo.lock`) so every `cog bump` commits the manifest+lockfile updates alongside `CHANGELOG.md`.
- Inject Rust toolchain + `cargo-edit` install steps into the upstream release job's `jobs.release.steps` via a new yaml: fragment, so the hooks have what they need on PATH.

The motivation: without this, `release-binaries.yaml` builds tagged artifacts whose `--version` output disagrees with the tarball filename — which is exactly how `v0.37.0` ended up needing a hand-applied fixup commit.

## Known issues blocking clean apply

The next `common-repo apply` will re-corrupt files in this PR:

- common-repo/common-repo#334 — `yaml:` merge op un-does template-vars substitution and strips comments on the destination file (affects `.github/workflows/release.yaml` post-apply).
- common-repo/semantic-release#13 — `cog.toml` has no `if-exists: preserve`, so consumer `pre_bump_hooks` get overwritten on apply.

Landing this anyway because the changes themselves are correct; the bugs are upstream `apply` pipeline issues that need fixes in those repos.

## Test plan

- [x] `cargo check` clean
- [x] `cargo metadata` confirms both `common-repo` and `xtask` resolve to `0.37.0` via the inherited workspace version
- [x] `./script/ci` clean (fmt, clippy, pre-commit, prose lint)
- [ ] Real-world validation: next push to `main` that warrants a bump should produce a commit containing `CHANGELOG.md` + `Cargo.toml` + `xtask/Cargo.toml` + `Cargo.lock` updates, tagged correctly. Requires #334 and #13 resolved (or the bot run on this exact state without an intervening `apply`).