### PR TITLE
ci: install cargo-edit in release job for cog set-version hook

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -35,6 +35,14 @@ jobs:
       version: ${{ steps.plan.outputs.version }}
       tag: ${{ steps.plan.outputs.tag }}
     steps:
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Install cargo-edit
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-edit
+
       - name: Generate app token
         id: app-token
         uses: actions/create-github-app-token@f8d387b68d61c58ab83c6c016672934102569859 # v3


### PR DESCRIPTION
## Problem

The most recent release run failed at the `Bump (commit + tag, local only)` step:

```
error: no such command: `set-version`
Error: prehook run `cargo set-version 0.37.1` failed
```

The release job runs `cog bump --auto`, and `cog.toml`'s `pre_bump_hooks` call `cargo set-version {{version}}` (to stamp `[workspace.package].version`), then `cargo check --release`, then `git add`. `cargo set-version` is provided by **cargo-edit**, which is not installed in the release runner.

## Why the workflow, not a cog hook

The install belongs in the CI environment, not in the version-bump hooks:

- `taiki-e/install-action` fetches a prebuilt cargo-edit binary in seconds; a `cargo install cargo-edit` shell hook would compile from source on every release.
- Provisioning is the environment's job — `pre_bump_hooks` should consume tools, not install them.
- The workflow fragment is the apply-safe extension point. cog.toml's `pre_bump_hooks` are actually overwritten on the next `common-repo apply` (semantic-release#13), so a cog hook would be the *less* durable option.

## Fix

Prepend two steps to `jobs.release.steps`, ahead of the bump step:

```yaml
- name: Install Rust
  uses: dtolnay/rust-toolchain@stable
- name: Install cargo-edit
  uses: taiki-e/install-action@v2
  with:
    tool: cargo-edit
```

These mirror the existing consumer fragment `.common-repo/release-rust-toolchain.yml` exactly. That fragment is wired into `release.yaml` via a `yaml:` merge op in `.common-repo.yaml`, but it was never materialized into the on-disk workflow (a clean `common-repo apply` is currently blocked by upstream bugs #334 / semantic-release#13). This hand-edit is a faithful stopgap: a future clean `apply` reformats the whole file but injects identical step content.

## Verification

- `action-validator` and `actionlint` pass on the edited workflow.
- Steps confirmed to byte-match the fragment as data (same action refs, `@stable`/`@v2` pins, `with: tool: cargo-edit`), prepended so cargo-edit is on PATH before `cog bump --auto`.
- No other release-blocking gap: `[workspace.package].version` is present, the `git add` paths exist, and `cargo check --release` needs no extra system deps.

Once merged, the release workflow re-runs against the pending `fix:` from #336 and should cut v0.37.1.
