### PR TITLE
fix: preserve file permissions when loading local files during apply

### DIFF
--- a/src/filesystem.rs
+++ b/src/filesystem.rs
@@ -38,6 +38,23 @@ use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::time::SystemTime;
 
+/// Read the Unix permission mode from a file's metadata.
+///
+/// Returns the full `mode()` on Unix and falls back to `0o644` on
+/// other platforms.
+fn permission_mode_from_metadata(metadata: &std::fs::Metadata) -> u32 {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        metadata.permissions().mode()
+    }
+    #[cfg(not(unix))]
+    {
+        let _ = metadata;
+        0o644
+    }
+}
+
 /// Represents a file with content and metadata
 #[derive(Debug, Clone)]
 pub struct File {
@@ -82,6 +99,28 @@ impl File {
             is_template: false,
             if_exists: IfExists::Overwrite,
         }
+    }
+
+    /// Creates a new `File` by reading content and metadata from a path on
+    /// disk.
+    ///
+    /// The file's permissions and modification time are taken from the
+    /// filesystem metadata so that executable bits (and other mode bits) are
+    /// preserved through the pipeline.
+    pub fn from_path(path: &Path) -> Result<Self> {
+        let content = std::fs::read(path).map_err(|e| Error::Filesystem {
+            message: format!("Failed to read '{}': {}", path.display(), e),
+        })?;
+        let metadata = std::fs::metadata(path).map_err(|e| Error::Filesystem {
+            message: format!("Failed to read metadata for '{}': {}", path.display(), e),
+        })?;
+        Ok(Self {
+            content,
+            permissions: permission_mode_from_metadata(&metadata),
+            modified_time: metadata.modified().unwrap_or(SystemTime::UNIX_EPOCH),
+            is_template: false,
+            if_exists: IfExists::Overwrite,
+        })
     }
 
     /// Creates a new `File` from a string slice.
@@ -348,6 +387,34 @@ mod tests {
         assert_eq!(file.content, content);
         assert_eq!(file.size(), 5);
         assert_eq!(file.permissions, 0o644);
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn test_file_from_path_preserves_permissions() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let temp_dir = tempfile::TempDir::new().unwrap();
+
+        let script = temp_dir.path().join("run.sh");
+        std::fs::write(&script, "#!/bin/sh\ntrue").unwrap();
+        std::fs::set_permissions(&script, std::fs::Permissions::from_mode(0o755)).unwrap();
+
+        let file = File::from_path(&script).unwrap();
+        assert_eq!(file.content, b"#!/bin/sh\ntrue");
+        assert_eq!(file.permissions & 0o777, 0o755);
+    }
+
+    #[test]
+    fn test_file_from_path_reads_content() {
+        let temp_dir = tempfile::TempDir::new().unwrap();
+
+        let txt = temp_dir.path().join("data.txt");
+        std::fs::write(&txt, "hello").unwrap();
+
+        let file = File::from_path(&txt).unwrap();
+        assert_eq!(file.content, b"hello");
+        assert_eq!(file.permissions & 0o777, 0o644);
     }
 
     #[test]

--- a/src/git.rs
+++ b/src/git.rs
@@ -197,9 +197,9 @@ fn load_directory_with_filter(
                     if remapped_path.as_os_str().is_empty() {
                         continue;
                     }
-                    add_file(fs, &path, remapped_path, &entry)?;
+                    add_file(fs, &path, remapped_path)?;
                 } else {
-                    add_file(fs, &path, relative_path, &entry)?;
+                    add_file(fs, &path, relative_path)?;
                 }
             }
         }
@@ -210,35 +210,8 @@ fn load_directory_with_filter(
     Ok(fs)
 }
 
-fn add_file(
-    fs: &mut MemoryFS,
-    abs_path: &Path,
-    dest: &Path,
-    entry: &fs::DirEntry,
-) -> Result<(), Error> {
-    let content = fs::read(abs_path)?;
-    let metadata = entry.metadata()?;
-    let permissions = {
-        #[cfg(unix)]
-        {
-            use std::os::unix::fs::PermissionsExt;
-            metadata.permissions().mode()
-        }
-        #[cfg(not(unix))]
-        {
-            0o644
-        }
-    };
-    let file = File {
-        content,
-        permissions,
-        modified_time: metadata
-            .modified()
-            .unwrap_or(std::time::SystemTime::UNIX_EPOCH),
-        is_template: false,
-        if_exists: crate::config::IfExists::Overwrite,
-    };
-    fs.add_file(dest, file)?;
+fn add_file(fs: &mut MemoryFS, abs_path: &Path, dest: &Path) -> Result<(), Error> {
+    fs.add_file(dest, File::from_path(abs_path)?)?;
     Ok(())
 }
 

--- a/src/phases/local_merge.rs
+++ b/src/phases/local_merge.rs
@@ -199,11 +199,8 @@ pub(crate) fn load_local_fs(working_dir: &Path) -> Result<MemoryFS> {
             continue;
         }
 
-        // Read file content
-        let content = std::fs::read(file_path)?;
-
-        // Add to filesystem with relative path
-        local_fs.add_file(relative_path, File::new(content))?;
+        // Read file content and metadata (preserves permissions)
+        local_fs.add_file(relative_path, File::from_path(file_path)?)?;
     }
 
     Ok(local_fs)
@@ -908,6 +905,45 @@ mod tests {
         assert!(!local_fs.exists("Thumbs.db"));
         assert!(!local_fs.exists("._resource"));
         assert!(local_fs.exists("real.txt"));
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn test_phase5_load_local_fs_preserves_executable_permissions() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let temp_dir = TempDir::new().unwrap();
+        let working_dir = temp_dir.path();
+
+        // Create a regular file (0o644) and an executable script (0o755)
+        std::fs::write(working_dir.join("readme.txt"), b"hello").unwrap();
+        std::fs::write(working_dir.join("install.sh"), b"#!/bin/sh\necho ok").unwrap();
+        std::fs::set_permissions(
+            working_dir.join("install.sh"),
+            std::fs::Permissions::from_mode(0o755),
+        )
+        .unwrap();
+
+        std::fs::create_dir_all(working_dir.join("script")).unwrap();
+        std::fs::write(working_dir.join("script/ci"), b"#!/bin/sh\nrun ci").unwrap();
+        std::fs::set_permissions(
+            working_dir.join("script/ci"),
+            std::fs::Permissions::from_mode(0o755),
+        )
+        .unwrap();
+
+        let local_fs = load_local_fs(working_dir).unwrap();
+
+        // Regular file keeps default permissions
+        let readme = local_fs.get_file("readme.txt").unwrap();
+        assert_eq!(readme.permissions & 0o777, 0o644);
+
+        // Executable files preserve their executable bit
+        let install = local_fs.get_file("install.sh").unwrap();
+        assert_eq!(install.permissions & 0o777, 0o755);
+
+        let ci = local_fs.get_file("script/ci").unwrap();
+        assert_eq!(ci.permissions & 0o777, 0o755);
     }
 
     #[test]

--- a/src/phases/orchestrator.rs
+++ b/src/phases/orchestrator.rs
@@ -589,13 +589,13 @@ fn execute_sequential_pipeline(
                     if !fs.exists(path) {
                         let disk_path = working_dir.join(path);
                         if disk_path.exists() {
-                            let content = std::fs::read(&disk_path)?;
+                            let file = crate::filesystem::File::from_path(&disk_path)?;
                             trace!(
                                 "op merge: pre-load from disk {} ({} bytes)",
                                 path,
-                                content.len(),
+                                file.content.len(),
                             );
-                            fs.add_file(path, crate::filesystem::File::new(content))?;
+                            fs.add_file(path, file)?;
                         }
                     }
                 }
@@ -621,8 +621,7 @@ fn execute_sequential_pipeline(
             if !fs.exists(path) {
                 let disk_path = working_dir.join(path);
                 if disk_path.exists() {
-                    let content = std::fs::read(&disk_path)?;
-                    fs.add_file(path, crate::filesystem::File::new(content))?;
+                    fs.add_file(path, crate::filesystem::File::from_path(&disk_path)?)?;
                 }
             }
         }

--- a/src/phases/write.rs
+++ b/src/phases/write.rs
@@ -202,6 +202,41 @@ mod tests {
         assert!(fs::read_dir(output_path).unwrap().next().is_none());
     }
 
+    /// Round-trip test: an executable file on disk is loaded via
+    /// `load_local_fs`, written back through the write phase, and
+    /// retains its executable bit. This is the regression test for
+    /// GitHub issue #318.
+    #[test]
+    #[cfg(unix)]
+    fn test_phase6_round_trip_preserves_executable_bit() {
+        use crate::phases::local_merge::load_local_fs;
+
+        let source_dir = TempDir::new().unwrap();
+        let output_dir = TempDir::new().unwrap();
+
+        // Seed the source directory with an executable script
+        let script_path = source_dir.path().join("install.sh");
+        fs::write(&script_path, "#!/bin/sh\necho ok").unwrap();
+        fs::set_permissions(&script_path, fs::Permissions::from_mode(0o755)).unwrap();
+
+        // Also add a regular file for contrast
+        fs::write(source_dir.path().join("readme.txt"), "hello").unwrap();
+
+        // Load → write round-trip
+        let loaded = load_local_fs(source_dir.path()).unwrap();
+        execute(&loaded, output_dir.path()).unwrap();
+
+        // Executable bit must survive the round-trip
+        let written_script = output_dir.path().join("install.sh");
+        let mode = fs::metadata(&written_script).unwrap().permissions().mode();
+        assert_eq!(mode & 0o777, 0o755);
+
+        // Regular file stays 0o644
+        let written_readme = output_dir.path().join("readme.txt");
+        let readme_mode = fs::metadata(&written_readme).unwrap().permissions().mode();
+        assert_eq!(readme_mode & 0o777, 0o644);
+    }
+
     #[test]
     fn test_phase6_overwrite_existing_file() {
         let temp_dir = TempDir::new().unwrap();


### PR DESCRIPTION
## Summary

- `load_local_fs()` used `File::new(content)` which defaults permissions to `0o644`, discarding the on-disk mode — every `apply` silently stripped executable bits from scripts like `install.sh` and `script/*`
- Added `File::from_path()` constructor that reads both content and metadata (including permissions) from disk, applied at all three call sites that load files from the working directory
- Consolidated duplicated permission-extraction logic from `git.rs` into the shared `permission_mode_from_metadata()` helper

Closes #318

## Test plan

- [x] Unit test: `test_file_from_path_preserves_permissions` — verifies `File::from_path` reads `0o755` from disk
- [x] Unit test: `test_file_from_path_reads_content` — verifies content and default `0o644`
- [x] Regression test: `test_phase5_load_local_fs_preserves_executable_permissions` — executable scripts in working dir retain `0o755` through `load_local_fs`
- [x] Round-trip test: `test_phase6_round_trip_preserves_executable_bit` — load from disk → write phase → verify `0o755` survives
- [x] All 1154 existing tests pass
- [x] `./script/ci` passes (fmt, clippy, prose, pre-commit)

https://claude.ai/code/session_01VA2QXnF6vKbKcWnmeFsy7d